### PR TITLE
[PR]Feature/admin approved and login constraints

### DIFF
--- a/care/src/main/java/com/animal/api/auth/controller/AdminAuthController.java
+++ b/care/src/main/java/com/animal/api/auth/controller/AdminAuthController.java
@@ -18,39 +18,34 @@ import com.animal.api.common.model.OkResponseDTO;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 사용자 기준 로그인 기능 컨트롤러 클래스
  * 
  * @author Whistler95
- * @since 2025-06-16
+ * @since 2025-06-20
  * @see com.animal.api.auth.model.response.LoginResponseDTO
+ *
  */
-
-@RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/auth")
-public class AuthController {
+@RequestMapping("/api/auth/admin")
+@RequiredArgsConstructor
+public class AdminAuthController {
 
 	private final AuthService authService;
-
+	
 	/**
-	 * 일반 , 보호시설 사용자 통합 로그인 메서드
 	 * 
-	 * @param LoginRequestDTO 로그인 폼
-	 * @session 로그인 한 사용자만의 정보 저장
-	 * @return 로그인 한 사용자의 정보 
+	 * @param LoginRequestDTO 관리자 계정
+	 * @session 관리자 간단 정보 저장
+	 * @return 로그인 한 관리자의 정보
 	 */
 	
 	@PostMapping("/login")
-	public ResponseEntity<?> login(@RequestBody LoginRequestDTO dto, HttpServletRequest request) {
-
-		LoginResponseDTO user = authService.login(dto);
-
-		HttpSession session = request.getSession(true);
-		session.setAttribute("loginUser", user);
+	public ResponseEntity<?> loginAdmin(@RequestBody LoginRequestDTO dto, HttpServletRequest request){
 		
-		return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<LoginResponseDTO>(200, "로그인 성공", user));
+		LoginResponseDTO admin = authService.loginAdmin(dto);
+		
+		HttpSession session = request.getSession(true);
+		session.setAttribute("loginAdmin", admin);
+		
+		return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<LoginResponseDTO>(200, "관리자 로그인 성공", admin));
 	}
-
-
-	
 }

--- a/care/src/main/java/com/animal/api/auth/controller/AuthController.java
+++ b/care/src/main/java/com/animal/api/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.animal.api.auth.controller;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import org.springframework.http.HttpStatus;
@@ -32,17 +33,33 @@ public class AuthController {
 	private final AuthService authService;
 
 	/**
-	 * 일반 , 보호시설 사용자의 통합 로그인 메서드
+	 * 일반 , 보호시설 사용자 통합 로그인 메서드
 	 * 
 	 * @param LoginRequestDTO 로그인 폼
-	 * @session 로그인 한 사용자의 정보 저장
-	 * @return 로그인 한 사용자의 정보
+	 * @session 로그인 한 사용자만의 정보 저장
+	 * @return 사용자: 로그인 한 사용자의 정보 / 관리자: 로그인 정보 일치
 	 */
 	@PostMapping("/login")
-	public ResponseEntity<?> login(@RequestBody LoginRequestDTO dto, HttpSession session) {
-		LoginResponseDTO response = authService.login(dto);
-		session.setAttribute("loginUser", response);
-		return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<LoginResponseDTO>(200, "로그인 성공", response));
+	public ResponseEntity<?> login(@RequestBody LoginRequestDTO dto, HttpServletRequest request) {
+
+		LoginResponseDTO user = authService.login(dto);
+		
+		//관리자 로그인
+		if(user.getUserTypeIdx() == 3) {
+			//세션 x
+			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<>(200, "관리자 로그인 성공", null));
+		}
+
+		//사용자 로그인
+		HttpSession session = request.getSession(true);
+		session.setAttribute("loginUser", user);
+		
+		return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<LoginResponseDTO>(200, "로그인 성공", user));
 	}
 
+	/**
+	 * 
+	 * 
+	 */
+	
 }

--- a/care/src/main/java/com/animal/api/auth/controller/BcryptTest.java
+++ b/care/src/main/java/com/animal/api/auth/controller/BcryptTest.java
@@ -1,0 +1,17 @@
+package com.animal.api.auth.controller;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class BcryptTest {
+
+	public static void main(String[] args) {
+
+		BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+		String encoderPassword = encoder.encode("12345");
+		
+		System.out.println("BCrypt 암호화된 비밀번호: " + encoderPassword);
+		
+		
+	}
+
+}

--- a/care/src/main/java/com/animal/api/auth/controller/LogoutController.java
+++ b/care/src/main/java/com/animal/api/auth/controller/LogoutController.java
@@ -1,0 +1,24 @@
+package com.animal.api.auth.controller;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.animal.api.common.model.OkResponseDTO;
+
+@RestController
+@RequestMapping("/api/auth")
+public class LogoutController {
+
+	@PostMapping("/logout")
+	public ResponseEntity<OkResponseDTO<String>> logout(HttpSession session){
+		if (session != null) {
+		    session.invalidate();
+		}
+		return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<>(200, "로그아웃이 완료되었습니다.", null));
+	}
+}

--- a/care/src/main/java/com/animal/api/auth/model/response/LoginResponseDTO.java
+++ b/care/src/main/java/com/animal/api/auth/model/response/LoginResponseDTO.java
@@ -28,7 +28,7 @@ public class LoginResponseDTO {
 	private LocalDate birthDate;
 
 	private String gender;
-	private int tel;
+	private String tel;
 
 	private int zipCode;
 	private String address;
@@ -54,7 +54,7 @@ public class LoginResponseDTO {
 	private Integer shelterTypeIdx;
 	private String shelterTypeName;
 
-	private Integer shelterTel;
+	private String shelterTel;
 	private String shelterName;
 	private String shelterPersonName;
 	private Integer shelterZipCode;

--- a/care/src/main/java/com/animal/api/auth/model/vo/ShelterVO.java
+++ b/care/src/main/java/com/animal/api/auth/model/vo/ShelterVO.java
@@ -8,7 +8,7 @@ public class ShelterVO {
 	private int userIdx;
 	private Integer shelterTypeIdx;
 	private String shelterTypeName;
-	private Integer shelterTel;
+	private String shelterTel;
 	private String shelterName;
 	private String shelterPersonName;
 	private Integer shelterZipCode;

--- a/care/src/main/java/com/animal/api/auth/model/vo/UserVO.java
+++ b/care/src/main/java/com/animal/api/auth/model/vo/UserVO.java
@@ -20,7 +20,7 @@ public class UserVO {
 
     private LocalDate birthDate;
     private String gender;
-    private int tel;
+    private String tel;
 
     private int zipCode;
     private String address;

--- a/care/src/main/java/com/animal/api/auth/service/AuthService.java
+++ b/care/src/main/java/com/animal/api/auth/service/AuthService.java
@@ -5,5 +5,9 @@ import com.animal.api.auth.model.response.LoginResponseDTO;
 
 public interface AuthService {
 
+	//일반 사용자 로그인
 	LoginResponseDTO login(LoginRequestDTO dto);
+	
+	//관리자 로그인
+	LoginResponseDTO loginAdmin(LoginRequestDTO dto);
 }

--- a/care/src/main/java/com/animal/api/auth/service/AuthServiceImple.java
+++ b/care/src/main/java/com/animal/api/auth/service/AuthServiceImple.java
@@ -33,7 +33,15 @@ public class AuthServiceImple implements AuthService {
 		if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
 			throw new CustomException(401, "비밀번호가 일치하지 않습니다");
 		}
+		
+		if(user.getStatus() == -1) {
+			throw new CustomException(410, "탈퇴한 회원입니다.");
+		}
 
+		if(user.getUserTypeIdx() == 2 & user.getStatus() == 0) {
+			throw new CustomException(403, "보호시설 계정은 관리자 승인 후 로그인할 수 있습니다.");
+		}
+		
 		authMapper.updateLastLoginAt(user.getIdx());
 
 		LoginResponseDTO res = new LoginResponseDTO();

--- a/care/src/main/java/com/animal/api/auth/service/AuthServiceImple.java
+++ b/care/src/main/java/com/animal/api/auth/service/AuthServiceImple.java
@@ -42,6 +42,14 @@ public class AuthServiceImple implements AuthService {
 			throw new CustomException(403, "보호시설 계정은 관리자 승인 후 로그인할 수 있습니다.");
 		}
 		
+		if(user.getUserTypeIdx() == 3) {
+			//관리자 로직 처리 추가 예정
+		}
+		
+		if(user.getUserTypeIdx() != 3) {
+			throw new CustomException(403, "관리자 권한이 없습니다.");
+		}
+		
 		authMapper.updateLastLoginAt(user.getIdx());
 
 		LoginResponseDTO res = new LoginResponseDTO();
@@ -90,5 +98,7 @@ public class AuthServiceImple implements AuthService {
 		}
 
 		return res;
+		
+		
 	}
 }

--- a/care/src/main/java/com/animal/api/common/exception/GlobalExceptionHandler.java
+++ b/care/src/main/java/com/animal/api/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.animal.api.common.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -9,6 +10,7 @@ import com.animal.api.common.model.ErrorResponseDTO;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponseDTO> handleCustomException(CustomException e) {
 		ErrorResponseDTO error = new ErrorResponseDTO(e.getStatusCode(), e.getMessage());
@@ -20,4 +22,18 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponseDTO> handleGeneralException(Exception e) {
 		return ResponseEntity.status(500).body(new ErrorResponseDTO(500, "서버 내부 오류: " + e.getMessage()));
 	}
+	
+	//회원가입 유효성 검사 통과 못했을 시
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponseDTO> handleValidationException(MethodArgumentNotValidException ex){ 
+		
+		String message = ex.getBindingResult().getFieldErrors().stream()
+				.map(error -> error.getField() + ":" + error.getDefaultMessage())
+				.findFirst()
+				.orElse("입력값이 유효하지 않습니다");
+		
+		return ResponseEntity.badRequest().body(new ErrorResponseDTO(400, message));
+	}
+
+
 }

--- a/care/src/main/java/com/animal/api/signup/controller/SignupController.java
+++ b/care/src/main/java/com/animal/api/signup/controller/SignupController.java
@@ -22,7 +22,7 @@ import com.animal.api.signup.service.SignupService;
  * @see com.animal.api.signup.model.request.UserSignupRequestDTO, com.animal.api.signup.model.request.ShelterSignupRequestDTO
  */
 @RestController
-@RequestMapping("/signup")
+@RequestMapping("/api/signup")
 public class SignupController {
 
 	@Autowired
@@ -47,7 +47,7 @@ public class SignupController {
 	 */
     // 보호소 회원가입
     @PostMapping("/shelter")
-    public ResponseEntity<OkResponseDTO<String>> signupShelter(@RequestBody ShelterSignupRequestDTO dto) {
+    public ResponseEntity<OkResponseDTO<String>> signupShelter(@Valid @RequestBody ShelterSignupRequestDTO dto) {
         signupService.signupShelter(dto);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(new OkResponseDTO<>(201, "보호소 회원가입이 요청이 완료되었습니다.", null));

--- a/care/src/main/java/com/animal/api/signup/controller/SignupController.java
+++ b/care/src/main/java/com/animal/api/signup/controller/SignupController.java
@@ -1,5 +1,7 @@
 package com.animal.api.signup.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,11 +31,12 @@ public class SignupController {
 	/**
 	 * 일반 사용자 회원가입 메서드
 	 * @param UserSignupRequestDTO 회원가입 폼
+	 * @Valid UserSignupRequestDTO 유효성 검사 
 	 * @return 회원가입 완료
 	 */
 	//일반 사용자 회원가입
 	@PostMapping("/user")
-	public ResponseEntity<OkResponseDTO<String>> signup(@RequestBody UserSignupRequestDTO dto){
+	public ResponseEntity<OkResponseDTO<String>> signup(@Valid @RequestBody UserSignupRequestDTO dto){
 		signupService.signupUser(dto);
 		return ResponseEntity.status(HttpStatus.CREATED).body(new OkResponseDTO<>(201, "회원가입이 완료되었습니다", null));
 	}

--- a/care/src/main/java/com/animal/api/signup/model/request/ShelterSignupRequestDTO.java
+++ b/care/src/main/java/com/animal/api/signup/model/request/ShelterSignupRequestDTO.java
@@ -2,39 +2,86 @@ package com.animal.api.signup.model.request;
 
 import java.time.LocalDate;
 
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 import lombok.Data;
 
 @Data
 public class ShelterSignupRequestDTO {
 
     // USERS 테이블 정보
+	@NotBlank(message = "아이디는 필수 입력 항목입니다")
+	@Pattern(regexp = "^[a-z0-9]{6,10}$", message = "아이디는 영문 소문자와 숫자 조합으로 6~10자 이내여야 합니다")
     private String id;
+	
+	@NotBlank(message = "이메일은 필수 입력 항목 입니다")
+	@Email(message = "올바른 이메일 형식이 아닙니다")
     private String email;
+	
+	@NotBlank(message = "비밀번호는 필수 입력 항목입니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{9,20}$", 
+    message = "비밀번호는 공백 없이 영문, 숫자, 특수문자를 포함하여 9~20자 이내여야 합니다.")
     private String password;
 
+    @NotBlank(message = "이름은 필수 항목입니다.")
+    @Pattern(regexp = "^[가-힣]{2,5}$", message = "이름은 한글 2~5자여야 합니다.")
     private String name;
+    
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,20}$", message = "닉네임은 특수문자 없이 2~20자 이내여야 합니다.")
     private String nickname;
 
+    @NotNull(message = "생년월일은 필수 항목입니다.") 
     private LocalDate birthDate;
+    
+    @NotBlank(message = "성별은 필수 항목입니다.")
+    @Pattern(regexp = "^[MF]$", message = "성별은 남성 또는 여성이야 합니다.")
     private String gender;
+    
+    @NotNull(message = "전화번호는 필수 항목입니다.")
+    @Digits(integer = 11, fraction = 0, message = "전화번호는 숫자만 입력해야 합니다.")
     private Integer tel;
 
+    @NotNull(message = "우편번호는 필수 항목입니다.")
     private Integer zipCode;
+    
+    @NotBlank(message = "주소는 필수 항목입니다.")
     private String address;
+    
+    @NotBlank(message = "상세 주소는 필수 항목 입니다")
     private String addressDetail;
 
     // SHELTERS 테이블 공통
+    @NotNull(message = "보호소 유형은 필수입니다")
     private Integer shelterTypeIdx;
+
+    @NotNull(message = "보호소 연락처는 필수입니다")
+    @Digits(integer = 20, fraction = 0, message = "보호소 연락처는 숫자만 가능합니다")
     private Integer shelterTel;
+
+    @NotBlank(message = "보호소 이름은 필수입니다")
     private String shelterName;
+
+    @NotBlank(message = "담당자명은 필수입니다")
+    @Pattern(regexp = "^[가-힣a-zA-Z]{2,50}$", message = "담당자명은 한글 또는 영어 2~50자입니다")
     private String shelterPersonName;
+
+    @NotNull(message = "보호소 우편번호는 필수입니다")
     private Integer shelterZipCode;
+
+    @NotBlank(message = "보호소 주소는 필수입니다")
     private String shelterAddress;
+
     private String shelterAddressDetail;
+
     private String shelterDescription;
 
-    // 조건 분기
-    private String shelterEmail;         // 공공(1)
+    // 조건 분기 
+    private String shelterEmail; // 공공(1)
     private String shelterBusinessNumber; // 공공(1), 민간유(2)
     private Integer shelterBusinessFile;  // 민간유(2)
 	

--- a/care/src/main/java/com/animal/api/signup/model/request/ShelterSignupRequestDTO.java
+++ b/care/src/main/java/com/animal/api/signup/model/request/ShelterSignupRequestDTO.java
@@ -43,8 +43,8 @@ public class ShelterSignupRequestDTO {
     private String gender;
     
     @NotNull(message = "전화번호는 필수 항목입니다.")
-    @Digits(integer = 11, fraction = 0, message = "전화번호는 숫자만 입력해야 합니다.")
-    private Integer tel;
+    @Pattern(regexp = "^\\d{9,20}$", message = "전화번호는 숫자만 입력해야 합니다.")
+    private String tel;
 
     @NotNull(message = "우편번호는 필수 항목입니다.")
     private Integer zipCode;
@@ -60,8 +60,8 @@ public class ShelterSignupRequestDTO {
     private Integer shelterTypeIdx;
 
     @NotNull(message = "보호소 연락처는 필수입니다")
-    @Digits(integer = 20, fraction = 0, message = "보호소 연락처는 숫자만 가능합니다")
-    private Integer shelterTel;
+    @Pattern(regexp = "^\\d{9,20}$", message = "보호소 연락처는 숫자만 가능합니다")
+    private String shelterTel;
 
     @NotBlank(message = "보호소 이름은 필수입니다")
     private String shelterName;

--- a/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
+++ b/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
@@ -17,7 +17,7 @@ public class UserSignupRequestDTO {
 	@Pattern(regexp = "^[a-z0-9]{6,10}$", message = "아이디는 영문 소문자와 숫자 조합으로 6~10자 이내여야 합니다")
     private String id;
 	
-	@NotBlank(message = "이메일은 필수 항목 입니다")
+	@NotBlank(message = "이메일은 필수 입력 항목 입니다")
 	@Email(message = "올바른 이메일 형식이 아닙니다")
     private String email;
 	
@@ -27,11 +27,11 @@ public class UserSignupRequestDTO {
     private String password;
 
     @NotBlank(message = "이름은 필수 항목입니다.")
-    @Pattern(regexp = "^[가-힣]{2,5}$", message = "이름은 한글 2~5자여야 합니다.") // 외국인 포함하고 싶으면 조정 가능
+    @Pattern(regexp = "^[가-힣]{2,5}$", message = "이름은 한글 2~5자여야 합니다.")
     private String name;
     
     @NotBlank(message = "닉네임은 필수 항목입니다.")
-    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,10}$", message = "닉네임은 특수문자 없이 2~10자 이내여야 합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,20}$", message = "닉네임은 특수문자 없이 2~20자 이내여야 합니다.")
     private String nickname;
 
     @NotNull(message = "생년월일은 필수 항목입니다.")  

--- a/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
+++ b/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
@@ -2,24 +2,56 @@ package com.animal.api.signup.model.request;
 
 import java.time.LocalDate;
 
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
 import lombok.Data;
 
 @Data
 public class UserSignupRequestDTO {
 
+	@NotBlank(message = "아이디는 필수 입력 항목입니다")
+	@Pattern(regexp = "^[a-z0-9]{6,10}$", message = "아이디는 영문 소문자와 숫자 조합으로 6~10자 이내여야 합니다")
     private String id;
+	
+	@NotBlank(message = "이메일은 필수 항목 입니다")
+	@Email(message = "올바른 이메일 형식이 아닙니다")
     private String email;
+	
+	@NotBlank(message = "비밀번호는 필수 입력 항목입니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{9,20}$", 
+    message = "비밀번호는 공백 없이 영문, 숫자, 특수문자를 포함하여 9~20자 이내여야 합니다.")
     private String password;
 
+    @NotBlank(message = "이름은 필수 항목입니다.")
+    @Pattern(regexp = "^[가-힣]{2,5}$", message = "이름은 한글 2~5자여야 합니다.") // 외국인 포함하고 싶으면 조정 가능
     private String name;
+    
+    @NotBlank(message = "닉네임은 필수 항목입니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,10}$", message = "닉네임은 특수문자 없이 2~10자 이내여야 합니다.")
     private String nickname;
 
+    @NotNull(message = "생년월일은 필수 항목입니다.")  
     private LocalDate birthDate;
+    
+    @NotBlank(message = "성별은 필수 항목입니다.")
+    @Pattern(regexp = "^[MF]$", message = "성별은 남성 또는 여성이야 합니다.")   
     private String gender; // 'M' or 'F'
+    
+    @NotNull(message = "전화번호는 필수 항목입니다.")
+    @Digits(integer = 11, fraction = 0, message = "전화번호는 숫자만 입력해야 합니다.")   
     private Integer tel;
 
+    @NotNull(message = "우편번호는 필수 항목입니다.")
     private Integer zipCode;
+    
+    @NotBlank(message = "주소는 필수 항목입니다.")
     private String address;
+    
+    @NotBlank(message = "상세 주소는 필수 항목 입니다")
     private String addressDetail;
-	
+
 }

--- a/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
+++ b/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
@@ -42,8 +42,8 @@ public class UserSignupRequestDTO {
     private String gender; // 'M' or 'F'
     
     @NotNull(message = "전화번호는 필수 항목입니다.")
-    @Digits(integer = 11, fraction = 0, message = "전화번호는 숫자만 입력해야 합니다.")   
-    private Integer tel;
+    @Pattern(regexp = "^\\d{9,20}$", message = "전화번호는 숫자만 입력해야 합니다.")  
+    private String tel;
 
     @NotNull(message = "우편번호는 필수 항목입니다.")
     private Integer zipCode;

--- a/care/src/main/java/com/animal/api/signup/service/SignupServiceImple.java
+++ b/care/src/main/java/com/animal/api/signup/service/SignupServiceImple.java
@@ -93,6 +93,31 @@ public class SignupServiceImple implements SignupService {
 
 	    // 3. USERS 테이블에 insert
 	    signupMapper.insertUser(user);
+	    
+	    switch(dto.getShelterTypeIdx()) {
+	    	case 1: 
+	    		if(dto.getShelterEmail() == null || !dto.getShelterEmail().matches(".*@(go\\.kr|korea\\.kr|or\\.kr|kr)$")) {
+	    			throw new CustomException(400, "공공 보호소는 go.kr, korea.kr, or.kr 도메인의 이메일이 필요합니다");
+	            }
+	            if (dto.getShelterBusinessNumber() == null || dto.getShelterBusinessNumber().isBlank()) {
+	                throw new CustomException(400, "공공 보호소는 사업자등록번호가 필요합니다");
+	            }
+	            break;
+	            
+	    	case 2:
+	    		if(dto.getShelterBusinessNumber() == null || dto.getShelterBusinessNumber().isBlank()) {
+	    			throw new CustomException(400, "민간 보호소는 사업자 등록 번호가 필요합니다.");
+	    		}
+	    		if(dto.getShelterBusinessFile() == null) {
+	    			throw new CustomException(400, "민간 보호소는 사업자등록증 파일이 필요합니다.");
+	    		}
+	    		break;
+	    		
+	    	case 3: 
+	    		break;
+	    	default: 
+	    		throw new CustomException(400, "올바르지 않은 보호시설 유형입니다.");
+	    }
 
 	    // 4. SHELTER VO 생성
 	    ShelterVO shelter = new ShelterVO();


### PR DESCRIPTION
관리자 계정 로그인 / 관련 로직 추가 
회원가입 시 유효성 검사 구현
로그아웃 기능 추가

아이디는 영문 소문자와 숫자 조합으로 6자 ~10자 이내  -> 20자 까지로 다음 머지 시 변경
올바른 이메일 형식
비밀번호는 공백 없이 영문, 숫자, 특수문자를 포함하여 9~20자 이내
이름은 한글 2~5자
닉네임은 특수문자 없이 2~20자 이내
전화번호는 숫자만

어드민 경로로 로그인 
![image](https://github.com/user-attachments/assets/3839bbcc-2ecf-4b58-9740-4405eb2e42a0)

어드민 경로가 아닐 시
![image](https://github.com/user-attachments/assets/3dfe4832-6f3a-475e-9414-81ddf1d12586)

회원가입 시 유효성 검사 
![image](https://github.com/user-attachments/assets/0cb75c8a-f978-4c60-a2e3-f11887afbb9a)

로그아웃 
![image](https://github.com/user-attachments/assets/9a7e6248-01a5-48f6-95d5-53a9675a9e80)
