### PR TITLE
[PR]Feature/delete user donation usercomment

### DIFF
--- a/care/src/main/java/com/animal/api/donation/controller/UserDonationsController.java
+++ b/care/src/main/java/com/animal/api/donation/controller/UserDonationsController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.animal.api.auth.model.response.LoginResponseDTO;
-import com.animal.api.common.aop.auth.RequireLogin;
 import com.animal.api.common.model.ErrorResponseDTO;
 import com.animal.api.common.model.OkResponseDTO;
 import com.animal.api.donation.model.request.DonationCommentDeleteRequestDTO;
@@ -33,13 +32,14 @@ import com.animal.api.donation.service.UserDonationsService;
 
 /**
  * @author consgary
- * @since 2025.06.21
+ * @since 2025.06.22
  * @see com.animal.api.donation.model.response.AllDonationListResponseDTO
  * @see com.animal.api.donation.model.response.DonationDetailResponseDTO
  * @see com.animal.api.donation.model.response.AllDonationCommentsResponseDTO
  * @see com.animal.api.donation.model.response.AllDonationUserListResponseDTO
  * @see com.animal.api.donation.model.request.DonationCommentRequestDTO
  * @see com.animal.api.donation.model.request.DonationCommentUpdateRequestDTO
+ * @see com.animal.api.donation.model.request.DonationCommentDeleteRequestDTO
  */
 @RestController
 @RequestMapping("/api/donations")
@@ -193,6 +193,15 @@ public class UserDonationsController {
 		}
 	}
 
+	/**
+	 * 응원 댓글 삭제
+	 * 
+	 * @param idx     기부 번호
+	 * @param dcIdx   댓글 번호
+	 * @param dto     댓글 삭제를 위한 정보
+	 * @param session 로그인 검증용
+	 * @return 댓글 삭제 성공,실패 메세지
+	 */
 	@DeleteMapping("{idx}/comments/{dcIdx}")
 	public ResponseEntity<?> deleteDonationComment(@PathVariable int idx, @PathVariable int dcIdx,
 			@RequestBody DonationCommentDeleteRequestDTO dto, HttpSession session) {
@@ -205,8 +214,8 @@ public class UserDonationsController {
 		Map resultMap = service.deleteDonationComment(dto);
 
 		if ((int) resultMap.get("result") == service.DELETE_SUCCESS) {
-			return ResponseEntity.status(HttpStatus.NO_CONTENT)
-					.body(new OkResponseDTO<Void>(204, (String) resultMap.get("msg"), null));
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new OkResponseDTO<Void>(200, (String) resultMap.get("msg"), null));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 					.body(new ErrorResponseDTO(400, (String) resultMap.get("msg")));

--- a/care/src/main/java/com/animal/api/donation/controller/UserDonationsController.java
+++ b/care/src/main/java/com/animal/api/donation/controller/UserDonationsController.java
@@ -196,14 +196,14 @@ public class UserDonationsController {
 	/**
 	 * 응원 댓글 삭제
 	 * 
-	 * @param idx     기부 번호
-	 * @param dcIdx   댓글 번호
-	 * @param dto     댓글 삭제를 위한 정보
-	 * @param session 로그인 검증용
-	 * @return 댓글 삭제 성공,실패 메세지
+	 * @param donationIdx        기부 번호
+	 * @param donationCommentIdx 응원 댓글 번호
+	 * @param dto                댓글 삭제를 위한 정보
+	 * @param session            로그인 검증용
+	 * @return 댓글 삭제,성공 메세지
 	 */
-	@DeleteMapping("{idx}/comments/{dcIdx}")
-	public ResponseEntity<?> deleteDonationComment(@PathVariable int idx, @PathVariable int dcIdx,
+	@DeleteMapping("{donationIdx}/comments/{donationCommentIdx}")
+	public ResponseEntity<?> deleteDonationComment(@PathVariable int donationIdx, @PathVariable int donationCommentIdx,
 			@RequestBody DonationCommentDeleteRequestDTO dto, HttpSession session) {
 		LoginResponseDTO loginUser = (LoginResponseDTO) session.getAttribute("loginUser");
 

--- a/care/src/main/java/com/animal/api/donation/controller/UserDonationsController.java
+++ b/care/src/main/java/com/animal/api/donation/controller/UserDonationsController.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,8 +19,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.animal.api.auth.model.response.LoginResponseDTO;
+import com.animal.api.common.aop.auth.RequireLogin;
 import com.animal.api.common.model.ErrorResponseDTO;
 import com.animal.api.common.model.OkResponseDTO;
+import com.animal.api.donation.model.request.DonationCommentDeleteRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentUpdateRequestDTO;
 import com.animal.api.donation.model.response.AllDonationCommentsResponseDTO;
@@ -160,13 +163,13 @@ public class UserDonationsController {
 					.body(new ErrorResponseDTO(400, (String) resultMap.get("msg")));
 		}
 	}
-	
+
 	/**
-	 * 응원 댓글 수정 
+	 * 응원 댓글 수정
 	 * 
-	 * @param idx 기부 번호
-	 * @param dcIdx 댓글 번호
-	 * @param dto 댓글 수정 폼
+	 * @param idx     기부 번호
+	 * @param dcIdx   댓글 번호
+	 * @param dto     댓글 수정 폼
 	 * @param session 로그인 검증용
 	 * @return 댓글 수정 성공,실패 메세지
 	 */
@@ -184,6 +187,26 @@ public class UserDonationsController {
 		if ((int) resultMap.get("result") == service.POST_SUCCESS) {
 			return ResponseEntity.status(HttpStatus.OK)
 					.body(new OkResponseDTO<Void>(200, (String) resultMap.get("msg"), null));
+		} else {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+					.body(new ErrorResponseDTO(400, (String) resultMap.get("msg")));
+		}
+	}
+
+	@DeleteMapping("{idx}/comments/{dcIdx}")
+	public ResponseEntity<?> deleteDonationComment(@PathVariable int idx, @PathVariable int dcIdx,
+			@RequestBody DonationCommentDeleteRequestDTO dto, HttpSession session) {
+		LoginResponseDTO loginUser = (LoginResponseDTO) session.getAttribute("loginUser");
+
+		if (loginUser == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		Map resultMap = service.deleteDonationComment(dto);
+
+		if ((int) resultMap.get("result") == service.DELETE_SUCCESS) {
+			return ResponseEntity.status(HttpStatus.NO_CONTENT)
+					.body(new OkResponseDTO<Void>(204, (String) resultMap.get("msg"), null));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 					.body(new ErrorResponseDTO(400, (String) resultMap.get("msg")));

--- a/care/src/main/java/com/animal/api/donation/mapper/UserDonationsMapper.java
+++ b/care/src/main/java/com/animal/api/donation/mapper/UserDonationsMapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.animal.api.donation.model.request.DonationCommentDeleteRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentUpdateRequestDTO;
 import com.animal.api.donation.model.response.AllDonationCommentsResponseDTO;
@@ -25,4 +26,6 @@ public interface UserDonationsMapper {
 	public int addDonationComment(DonationCommentRequestDTO dto);
 
 	public int updateDonationComment(DonationCommentUpdateRequestDTO dto);
+
+	public int deleteDonationComment(DonationCommentDeleteRequestDTO dto);
 }

--- a/care/src/main/java/com/animal/api/donation/model/request/DonationCommentDeleteRequestDTO.java
+++ b/care/src/main/java/com/animal/api/donation/model/request/DonationCommentDeleteRequestDTO.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class DonationCommentDeleteRequestDTO {
 	private int idx;
+	private int userIdx;
 }

--- a/care/src/main/java/com/animal/api/donation/model/request/DonationCommentDeleteRequestDTO.java
+++ b/care/src/main/java/com/animal/api/donation/model/request/DonationCommentDeleteRequestDTO.java
@@ -1,0 +1,12 @@
+package com.animal.api.donation.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DonationCommentDeleteRequestDTO {
+	private int idx;
+}

--- a/care/src/main/java/com/animal/api/donation/service/UserDonationsService.java
+++ b/care/src/main/java/com/animal/api/donation/service/UserDonationsService.java
@@ -17,6 +17,7 @@ public interface UserDonationsService {
 	static int DONATION_NOT_FOUND = 3;
 	static int COMMENT_CONTENT_EMPTY = 4;
 	static int COMMENT_NOT_FOUND = 5;
+	static int DELETE_SUCCESS = 6;
 	static int ERROR = -1;
 
 	public List<AllDonationListResponseDTO> getAllDonations(int listSize, int cp);

--- a/care/src/main/java/com/animal/api/donation/service/UserDonationsService.java
+++ b/care/src/main/java/com/animal/api/donation/service/UserDonationsService.java
@@ -3,6 +3,7 @@ package com.animal.api.donation.service;
 import java.util.List;
 import java.util.Map;
 
+import com.animal.api.donation.model.request.DonationCommentDeleteRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentUpdateRequestDTO;
 import com.animal.api.donation.model.response.AllDonationCommentsResponseDTO;
@@ -29,4 +30,6 @@ public interface UserDonationsService {
 	public Map addDonationComment(DonationCommentRequestDTO dto);
 
 	public Map updateDonationComment(DonationCommentUpdateRequestDTO dto);
+
+	public int deleteDonationComment(DonationCommentDeleteRequestDTO dto);
 }

--- a/care/src/main/java/com/animal/api/donation/service/UserDonationsService.java
+++ b/care/src/main/java/com/animal/api/donation/service/UserDonationsService.java
@@ -31,5 +31,5 @@ public interface UserDonationsService {
 
 	public Map updateDonationComment(DonationCommentUpdateRequestDTO dto);
 
-	public int deleteDonationComment(DonationCommentDeleteRequestDTO dto);
+	public Map deleteDonationComment(DonationCommentDeleteRequestDTO dto);
 }

--- a/care/src/main/java/com/animal/api/donation/service/UserDonationsServiceImple.java
+++ b/care/src/main/java/com/animal/api/donation/service/UserDonationsServiceImple.java
@@ -156,8 +156,34 @@ public class UserDonationsServiceImple implements UserDonationsService {
 	}
 
 	@Override
-	public int deleteDonationComment(DonationCommentDeleteRequestDTO dto) {
+	public Map deleteDonationComment(DonationCommentDeleteRequestDTO dto) {
+		Map map = new HashMap();
+		int result = 0;
+		String msg = null;
+		Boolean errorCheck = false;
+		if (dto.getIdx() == 0) {
+			result = COMMENT_NOT_FOUND;
+			msg = "잘못된 접근:댓글정보없음";
+			errorCheck = true;
+		} else if (dto.getUserIdx() == 0) {
+			result = USER_NOT_FOUND;
+			msg = "잘못된 접근:유저정보없음";
+			errorCheck = true;
+		}
 
-		return 0;
+		if (!errorCheck) {
+			int count = mapper.deleteDonationComment(dto);
+
+			if (count > 0) {
+				result = POST_SUCCESS;
+				msg = "응원 댓글 삭제 성공";
+			} else {
+				result = ERROR;
+				msg = "잘못된 접근";
+			}
+		}
+		map.put("result", result);
+		map.put("msg", msg);
+		return map;
 	}
 }

--- a/care/src/main/java/com/animal/api/donation/service/UserDonationsServiceImple.java
+++ b/care/src/main/java/com/animal/api/donation/service/UserDonationsServiceImple.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.animal.api.donation.mapper.UserDonationsMapper;
+import com.animal.api.donation.model.request.DonationCommentDeleteRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentRequestDTO;
 import com.animal.api.donation.model.request.DonationCommentUpdateRequestDTO;
 import com.animal.api.donation.model.response.AllDonationCommentsResponseDTO;
@@ -152,5 +153,11 @@ public class UserDonationsServiceImple implements UserDonationsService {
 		map.put("result", result);
 		map.put("msg", msg);
 		return map;
+	}
+
+	@Override
+	public int deleteDonationComment(DonationCommentDeleteRequestDTO dto) {
+
+		return 0;
 	}
 }

--- a/care/src/main/java/com/animal/api/donation/service/UserDonationsServiceImple.java
+++ b/care/src/main/java/com/animal/api/donation/service/UserDonationsServiceImple.java
@@ -175,7 +175,7 @@ public class UserDonationsServiceImple implements UserDonationsService {
 			int count = mapper.deleteDonationComment(dto);
 
 			if (count > 0) {
-				result = POST_SUCCESS;
+				result = DELETE_SUCCESS;
 				msg = "응원 댓글 삭제 성공";
 			} else {
 				result = ERROR;

--- a/care/src/main/resources/sql-mapper/donation/UserDonationsMapper.xml
+++ b/care/src/main/resources/sql-mapper/donation/UserDonationsMapper.xml
@@ -88,4 +88,12 @@ WHERE
 	AND USER_IDX = #{userIdx}
 	AND DONATION_IDX = #{donationIdx}
 </update>
+
+<delete id="deleteDonationComment" parameterType="int">
+DELETE
+FROM
+	DONATION_COMMENTS
+WHERE
+	IDX = #{idx}
+</delete>
 </mapper>

--- a/care/src/main/resources/sql-mapper/donation/UserDonationsMapper.xml
+++ b/care/src/main/resources/sql-mapper/donation/UserDonationsMapper.xml
@@ -95,5 +95,6 @@ FROM
 	DONATION_COMMENTS
 WHERE
 	IDX = #{idx}
+	AND USER_IDX = #{userIdx}
 </delete>
 </mapper>

--- a/care/src/main/resources/sql-mapper/donation/UserDonationsMapper.xml
+++ b/care/src/main/resources/sql-mapper/donation/UserDonationsMapper.xml
@@ -89,7 +89,7 @@ WHERE
 	AND DONATION_IDX = #{donationIdx}
 </update>
 
-<delete id="deleteDonationComment" parameterType="int">
+<delete id="deleteDonationComment" parameterType="com.animal.api.donation.model.request.DonationCommentDeleteRequestDTO">
 DELETE
 FROM
 	DONATION_COMMENTS


### PR DESCRIPTION
기부 상세페이지 응원댓글 삭제 기능을 구현했습니다.
(데이터 삭제 성공은 204인데 204로 하면 포스트맨에 메세지 출력이 안되서 200으로 했습니다.)

**URL:/api/donations/{donationIdx}/comments/{donationCommentIdx}**

로그인 검증
![1로그인전](https://github.com/user-attachments/assets/eaf3c447-e87c-4f2d-a07c-05f6ce33b293)

로그인 성공 (userIdx = 1)
![2로그인성공 (useridx=1)](https://github.com/user-attachments/assets/7876f682-8c67-42e6-b252-f8bd03446362)

댓글 삭제 성공(200)
![3댓글 삭제성공](https://github.com/user-attachments/assets/38863f80-8383-4209-8907-ffd0faacbf91)

댓글 정보 없음(400)
![4 댓글정보없음](https://github.com/user-attachments/assets/f1fc32bb-1009-443a-8cb7-0336526d3e80)

유저 정보 없음(400)
![5유저정보없음](https://github.com/user-attachments/assets/c2cd1129-839a-45a1-8d60-949d56fa4d61)

잘못된 유저정보(400)
![6잘못된 유저정보](https://github.com/user-attachments/assets/a9b7dba7-feeb-4591-b3a8-76cd1c7955a1)

잘못된 기부정보(400)
![7잘못된 기부댓글정보](https://github.com/user-attachments/assets/2fa75efd-3ec5-4021-8e28-73bc09b4a561)
