### PR TITLE
[PR]Feature/get shelter adoption review

### DIFF
--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -20,6 +20,7 @@ import com.animal.api.common.model.ErrorResponseDTO;
 import com.animal.api.common.model.OkResponseDTO;
 import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestDTO;
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
+import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
 import com.animal.api.management.shelter.service.ShelterManageService;
 
@@ -36,11 +37,11 @@ public class ShelterManageController {
 
 	@Autowired
 	private ShelterManageService shelterService;
-	
+
 	/**
 	 * 로그인 및 보호시설 사용자 검증 메서드
 	 * 
-	 * @param session 로그인 검증 세션 
+	 * @param session 로그인 검증 세션
 	 * 
 	 * @return 보호시설 계정으로 로그인한 관리자
 	 */
@@ -128,6 +129,32 @@ public class ShelterManageController {
 		int userIdx = loginUser.getIdx();
 
 		List<ManageVolunteerReviewResponseDTO> reviewList = shelterService.getVolunteerReview(listSize, cp, userIdx);
+
+		if (reviewList == null) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "리뷰글이 존재하지 않음"));
+		} else if (reviewList.size() == 0) {
+			return ResponseEntity.ok(new OkResponseDTO<>(200, "등록된 리뷰가 없습니다", reviewList));
+		} else {
+			return ResponseEntity.ok(new OkResponseDTO<>(200, "리뷰 조회 성공", reviewList));
+		}
+	}
+
+	@GetMapping("/reviews/adoption")
+	public ResponseEntity<?> getAdoptionReview(@RequestParam(value = "cp", defaultValue = "0") int cp,
+			HttpSession session) {
+
+		int listSize = 5;
+		if (cp == 0) {
+			cp = 1;
+		} else {
+			cp = (cp - 1) * listSize;
+		}
+
+		LoginResponseDTO loginUser = shelterUserCheck(session);
+
+		int userIdx = loginUser.getIdx();
+
+		List<ManageAdoptionReviewResponseDTO> reviewList = shelterService.getAdoptionReview(listSize, cp, userIdx);
 
 		if (reviewList == null) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "리뷰글이 존재하지 않음"));

--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -138,7 +138,15 @@ public class ShelterManageController {
 			return ResponseEntity.ok(new OkResponseDTO<>(200, "리뷰 조회 성공", reviewList));
 		}
 	}
-
+	
+	/**
+	 * 해당 보호시설 입양 리뷰 조회 메서드
+	 * 
+	 * @param cp 현재 페이지 번호
+	 * @param session 로그인 검증 세션
+	 * 
+	 * @return 로그인한 보호시설의 사용자 입양 리뷰 조회
+	 */
 	@GetMapping("/reviews/adoption")
 	public ResponseEntity<?> getAdoptionReview(@RequestParam(value = "cp", defaultValue = "0") int cp,
 			HttpSession session) {

--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -35,6 +35,8 @@ public class ShelterManageController {
 
 	@Autowired
 	private ShelterManageService shelterService;
+	
+
 
 	/**
 	 * 보호시설 기본정보 조회 메서드
@@ -51,6 +53,10 @@ public class ShelterManageController {
 		if (loginUser == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용가능"));
 		}
+		if (loginUser.getUserTypeIdx() != 2) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "보호소 사용자만 접근 가능"));
+		}
+
 		int userIdx = loginUser.getIdx();
 
 		AllManageShelterResponseDTO dto = shelterService.getShelterInfo(userIdx);
@@ -73,8 +79,12 @@ public class ShelterManageController {
 	public ResponseEntity<?> updateShelterInfo(@RequestBody ShelterInfoUpdateRequestDTO dto, HttpSession session) {
 
 		LoginResponseDTO loginUser = (LoginResponseDTO) session.getAttribute("loginUser");
+		
 		if (loginUser == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용가능"));
+		}
+		if (loginUser.getUserTypeIdx() != 2) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "보호소 사용자만 접근 가능"));
 		}
 
 		int userIdx = loginUser.getIdx();
@@ -110,6 +120,10 @@ public class ShelterManageController {
 		LoginResponseDTO loginUser = (LoginResponseDTO) session.getAttribute("loginUser");
 		if (loginUser == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용가능"));
+		}
+		
+		if (loginUser.getUserTypeIdx() != 2) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "보호소 사용자만 접근 가능"));
 		}
 
 		int userIdx = loginUser.getIdx();

--- a/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
+++ b/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Mapper;
 
 import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestDTO;
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
+import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
 
 @Mapper
@@ -17,5 +18,7 @@ public interface ManagementShelterMapper {
 	public int updateSheterInfo(ShelterInfoUpdateRequestDTO dto);
 
 	public List<ManageVolunteerReviewResponseDTO> getVolunteerReview(Map map);
+
+	public List<ManageAdoptionReviewResponseDTO> getAdoptionReview(Map map);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/model/response/ManageAdoptionReviewResponseDTO.java
+++ b/care/src/main/java/com/animal/api/management/shelter/model/response/ManageAdoptionReviewResponseDTO.java
@@ -2,6 +2,8 @@ package com.animal.api.management.shelter.model.response;
 
 import java.sql.Timestamp;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,11 +13,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ManageAdoptionReviewResponseDTO {
 
-	private int idx;
-	private int userIdx;
+	private int reviewIdx;
 	private String nickName;
 	private String animalName;
 	private String content;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
 	private Timestamp createdAt;
 	private int ref;
 	private int lev;

--- a/care/src/main/java/com/animal/api/management/shelter/model/response/ManageAdoptionReviewResponseDTO.java
+++ b/care/src/main/java/com/animal/api/management/shelter/model/response/ManageAdoptionReviewResponseDTO.java
@@ -1,0 +1,24 @@
+package com.animal.api.management.shelter.model.response;
+
+import java.sql.Timestamp;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ManageAdoptionReviewResponseDTO {
+
+	private int idx;
+	private int userIdx;
+	private String nickName;
+	private String animalName;
+	private String content;
+	private Timestamp createdAt;
+	private int ref;
+	private int lev;
+	private int turn;
+
+}

--- a/care/src/main/java/com/animal/api/management/shelter/model/response/ManageVolunteerReviewResponseDTO.java
+++ b/care/src/main/java/com/animal/api/management/shelter/model/response/ManageVolunteerReviewResponseDTO.java
@@ -14,11 +14,11 @@ import lombok.NoArgsConstructor;
 public class ManageVolunteerReviewResponseDTO {
 
 	private int reviewIdx;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-	private Timestamp reviewDate;
-	private String reviewWriter;
-	private String reviewContent;
+	private String nickName;
 	private String volunteerTitle;
+	private String content;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	private Timestamp createdAt;
 	private int ref;
 	private int lev;
 	private int turn;

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestDTO;
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
+import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
 
 public interface ShelterManageService {
@@ -13,5 +14,7 @@ public interface ShelterManageService {
 	public int updateSheterInfo(ShelterInfoUpdateRequestDTO dto);
 	
 	public List<ManageVolunteerReviewResponseDTO> getVolunteerReview(int listSize, int cp, int idx);
+	
+	public List<ManageAdoptionReviewResponseDTO> getAdoptionReview(int listSize, int cp, int idx);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import com.animal.api.management.shelter.mapper.ManagementShelterMapper;
 import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestDTO;
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
+import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
 
 @Service
@@ -44,6 +45,18 @@ public class ShelterManageServiceImple implements ShelterManageService {
 		map.put("idx", idx);
 		
 		List<ManageVolunteerReviewResponseDTO> reviewLists = mapper.getVolunteerReview(map);
+		return reviewLists;
+	}
+	
+	@Override
+	public List<ManageAdoptionReviewResponseDTO> getAdoptionReview(int listSize, int cp, int idx) {
+		Map<String, Integer> map = new HashMap<String, Integer>();
+		
+		map.put("listSize", listSize);
+		map.put("cp", cp);
+		map.put("idx", idx);
+		
+		List<ManageAdoptionReviewResponseDTO> reviewLists = mapper.getAdoptionReview(map);
 		return reviewLists;
 	}
 }

--- a/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
@@ -47,12 +47,12 @@ WHERE
 
 <select id="getVolunteerReview" parameterType="int" resultType="com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO">
 SELECT
-	VR.IDX as reviewIdx,
-	VR.CONTENT as reviewContent,
-	VR.CREATED_AT as reviewDate,
-	REVIEWER.NICKNAME as reviewWriter,
-	V.TITLE as volunteerTitle,
-	V.IDX as volunteerIdx,
+	VR.IDX AS reviewIdx,
+	VR.CONTENT AS reviewContent,
+	VR.CREATED_AT AS reviewDate,
+	REVIEWER.NICKNAME AS reviewWriter,
+	V.TITLE AS volunteerTitle,
+	V.IDX AS volunteerIdx,
 	VR.REF,
 	VR.LEV,
 	VR.TURN
@@ -67,6 +67,31 @@ WHERE
 ORDER BY
 	VR.REF DESC,
 	VR.TURN ASC
+LIMIT
+#{listSize} OFFSET #{cp};
+</select>
+
+<select id="getAdoptionReview" parameterType="int" resultType="com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO">
+SELECT
+	AR.IDX AS reviewIdx,
+	AR.CONTENT AS reviewContent,
+	U.NICKNAME,
+	A.NAME AS animalName,
+	AR.CONTENT,
+	AR.CREATED_AT as createdAt,
+	AR.REF,
+	AR.TURN
+FROM
+	ADOPTION_REVIEWS AR
+JOIN ANIMALS A ON
+	AR.ANIMAL_IDX = A.IDX
+JOIN USERS U ON
+	AR.ANIMAL_IDX = U.IDX
+WHERE
+	A.USER_IDX = #{idx}
+ORDER BY
+	AR.REF DESC,
+	AR.TURN ASC
 LIMIT
 #{listSize} OFFSET #{cp};
 </select>

--- a/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
@@ -48,9 +48,9 @@ WHERE
 <select id="getVolunteerReview" parameterType="int" resultType="com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO">
 SELECT
 	VR.IDX AS reviewIdx,
-	VR.CONTENT AS reviewContent,
-	VR.CREATED_AT AS reviewDate,
-	REVIEWER.NICKNAME AS reviewWriter,
+	VR.CONTENT,
+	VR.CREATED_AT AS createdAt,
+	REVIEWER.NICKNAME,
 	V.TITLE AS volunteerTitle,
 	V.IDX AS volunteerIdx,
 	VR.REF,
@@ -74,7 +74,7 @@ LIMIT
 <select id="getAdoptionReview" parameterType="int" resultType="com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO">
 SELECT
 	AR.IDX AS reviewIdx,
-	AR.CONTENT AS reviewContent,
+	AR.CONTENT AS content,
 	U.NICKNAME,
 	A.NAME AS animalName,
 	AR.CONTENT,


### PR DESCRIPTION
- 보호소 아이디로 로그인한 해당 보호소의 입양 리뷰 조회
- 로그인 시 매번 보호소 확인&로그인유무 검증하므로 메서드화 해서 사용
(로그인 검증 시에는 loginUser만 반환하고 싶어 반환타입을 LoginUserDTO로 사용 했습니다..)
- 나머지 미추가 했던 메서드에도 보호소 검증도 추가했음
- URL : care/api/management/shelter/reviews/adoption

**<보호소가 아닌 계정으로 접근했을 시>**
<img width="715" alt="image" src="https://github.com/user-attachments/assets/05e2e1b8-bcf8-4159-982c-74e7e0900cb5" />

**<보호소 로그인 후 해당 보호소의 입양 리뷰 조회>**
<img width="741" alt="image" src="https://github.com/user-attachments/assets/e1dfbd4f-bbef-4543-9417-b092e391af91" />
