### PR TITLE
✏️ [PR]Tranjection expcation fix

### DIFF
--- a/care/src/main/java/com/animal/api/auth/model/vo/ShelterVO.java
+++ b/care/src/main/java/com/animal/api/auth/model/vo/ShelterVO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ShelterVO {
 	
-	private int userIdx;
+	private Integer userIdx;
 	private Integer shelterTypeIdx;
 	private String shelterTypeName;
 	private String shelterTel;

--- a/care/src/main/java/com/animal/api/auth/model/vo/UserVO.java
+++ b/care/src/main/java/com/animal/api/auth/model/vo/UserVO.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserVO {
 	
-    private int idx;
+    private Integer idx;
     private int userTypeIdx;
     private String userTypeName;
 

--- a/care/src/main/java/com/animal/api/common/exception/GlobalExceptionHandler.java
+++ b/care/src/main/java/com/animal/api/common/exception/GlobalExceptionHandler.java
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<ErrorResponseDTO> handleValidationException(MethodArgumentNotValidException ex){ 
 		
 		String message = ex.getBindingResult().getFieldErrors().stream()
-				.map(error -> error.getField() + ":" + error.getDefaultMessage())
+				.map(error -> error.getDefaultMessage())
 				.findFirst()
 				.orElse("입력값이 유효하지 않습니다");
 		

--- a/care/src/main/java/com/animal/api/signup/controller/SignupController.java
+++ b/care/src/main/java/com/animal/api/signup/controller/SignupController.java
@@ -16,7 +16,8 @@ import com.animal.api.common.aop.email.RequireEmailVerified;
 import com.animal.api.common.model.OkResponseDTO;
 import com.animal.api.signup.model.request.ShelterSignupRequestDTO;
 import com.animal.api.signup.model.request.UserSignupRequestDTO;
-import com.animal.api.signup.service.SignupService;
+import com.animal.api.signup.service.ShelterSignupService;
+import com.animal.api.signup.service.UserSignupService;
 
 /**
  * 일반 사용자/ 보호시설 회원가입 컨트롤러 클래스
@@ -29,7 +30,9 @@ import com.animal.api.signup.service.SignupService;
 public class SignupController {
 
 	@Autowired
-	private SignupService signupService;
+	private ShelterSignupService signupService;
+	@Autowired
+	private UserSignupService userSignupService;
 	
 	/**
 	 * 일반 사용자 회원가입 메서드
@@ -43,7 +46,7 @@ public class SignupController {
 	@RequireEmailVerified
 	public ResponseEntity<OkResponseDTO<String>> signup(@Valid @RequestBody UserSignupRequestDTO dto, HttpServletRequest request){
 		
-		signupService.signupUser(dto);
+		userSignupService.signupUser(dto);
 		
 		//인증 완료 후 세션 정리
 		HttpSession session = request.getSession(false);

--- a/care/src/main/java/com/animal/api/signup/mapper/SignupMapper.java
+++ b/care/src/main/java/com/animal/api/signup/mapper/SignupMapper.java
@@ -5,7 +5,6 @@ import org.apache.ibatis.annotations.Mapper;
 import com.animal.api.auth.model.vo.ShelterVO;
 import com.animal.api.auth.model.vo.UserVO;
 
-@Mapper
 public interface SignupMapper {
 
     int isDuplicateId(String id);

--- a/care/src/main/java/com/animal/api/signup/mapper/SignupMapper.java
+++ b/care/src/main/java/com/animal/api/signup/mapper/SignupMapper.java
@@ -5,6 +5,7 @@ import org.apache.ibatis.annotations.Mapper;
 import com.animal.api.auth.model.vo.ShelterVO;
 import com.animal.api.auth.model.vo.UserVO;
 
+@Mapper
 public interface SignupMapper {
 
     int isDuplicateId(String id);

--- a/care/src/main/java/com/animal/api/signup/model/request/ShelterSignupRequestDTO.java
+++ b/care/src/main/java/com/animal/api/signup/model/request/ShelterSignupRequestDTO.java
@@ -17,73 +17,74 @@ import lombok.NoArgsConstructor;
 public class ShelterSignupRequestDTO {
 
     // USERS 테이블 정보
-	@NotBlank(message = "아이디는 필수 입력 항목입니다")
-	@Pattern(regexp = "^[a-z0-9]{6,20}$", message = "아이디는 영문 소문자와 숫자 조합으로 6~20자 이내여야 합니다")
+    @NotBlank(message = "아이디는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^[a-z0-9]{6,20}$", message = "아이디는 영문 소문자와 숫자 조합으로 6~20자 이내여야 합니다.")
     private String id;
-	
-	@NotBlank(message = "이메일은 필수 입력 항목 입니다")
-	@Email(message = "올바른 이메일 형식이 아닙니다")
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
-	
-	@NotBlank(message = "비밀번호는 필수 입력 항목입니다")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{9,20}$", 
-    message = "비밀번호는 공백 없이 영문, 숫자, 특수문자를 포함하여 9~20자 이내여야 합니다.")
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{9,20}$",
+        message = "비밀번호는 공백 없이 영문, 숫자, 특수문자를 포함하여 9~20자 이내여야 합니다."
+    )
     private String password;
 
     @NotBlank(message = "이름은 필수 항목입니다.")
     @Pattern(regexp = "^[가-힣]{2,5}$", message = "이름은 한글 2~5자여야 합니다.")
     private String name;
-    
+
     @NotBlank(message = "닉네임은 필수 항목입니다.")
     @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,20}$", message = "닉네임은 특수문자 없이 2~20자 이내여야 합니다.")
     private String nickname;
 
-    @NotNull(message = "생년월일은 필수 항목입니다.") 
+    @NotNull(message = "생년월일은 필수 항목입니다.")
     private LocalDate birthDate;
-    
+
     @NotBlank(message = "성별은 필수 항목입니다.")
-    @Pattern(regexp = "^[MF]$", message = "성별은 남성 또는 여성이야 합니다.")
+    @Pattern(regexp = "^[MF]$", message = "성별은 M 또는 F여야 합니다.")
     private String gender;
-    
-    @NotNull(message = "전화번호는 필수 항목입니다.")
-    @Pattern(regexp = "^\\d{9,20}$", message = "전화번호는 숫자만 입력해야 합니다.")
+
+    @NotBlank(message = "전화번호는 필수 항목입니다.")
+    @Pattern(regexp = "^\\d{9,20}$", message = "전화번호는 숫자만 입력하며 9~20자 이내여야 합니다.")
     private String tel;
 
     @NotNull(message = "우편번호는 필수 항목입니다.")
     private Integer zipCode;
-    
+
     @NotBlank(message = "주소는 필수 항목입니다.")
     private String address;
-    
-    @NotBlank(message = "상세 주소는 필수 항목 입니다")
+
     private String addressDetail;
 
     // SHELTERS 테이블 공통
-    @NotNull(message = "보호소 유형은 필수입니다")
+    @NotNull(message = "보호소 유형은 필수입니다.")
     private Integer shelterTypeIdx;
 
-    @NotNull(message = "보호소 연락처는 필수입니다")
-    @Pattern(regexp = "^\\d{9,20}$", message = "보호소 연락처는 숫자만 가능합니다")
+    @NotBlank(message = "보호소 연락처는 필수입니다.")
+    @Pattern(regexp = "^\\d{9,20}$", message = "보호소 연락처는 숫자만 입력하며 9~20자 이내여야 합니다.")
     private String shelterTel;
 
-    @NotBlank(message = "보호소 이름은 필수입니다")
+    @NotBlank(message = "보호소 이름은 필수입니다.")
     private String shelterName;
 
-    @NotBlank(message = "담당자명은 필수입니다")
-    @Pattern(regexp = "^[가-힣a-zA-Z]{2,50}$", message = "담당자명은 한글 또는 영어 2~50자입니다")
+    @NotBlank(message = "담당자명은 필수입니다.")
+    @Pattern(regexp = "^[가-힣a-zA-Z]{2,50}$", message = "담당자명은 한글 또는 영어 2~50자여야 합니다.")
     private String shelterPersonName;
 
-    @NotNull(message = "보호소 우편번호는 필수입니다")
+    @NotNull(message = "보호소 우편번호는 필수입니다.")
     private Integer shelterZipCode;
 
-    @NotBlank(message = "보호소 주소는 필수입니다")
+    @NotBlank(message = "보호소 주소는 필수입니다.")
     private String shelterAddress;
 
     private String shelterAddressDetail;
 
     private String shelterDescription;
 
-    // 조건 분기 
+    // 조건 분기
     private String shelterEmail; // 공공(1)
     private String shelterBusinessNumber; // 공공(1), 민간유(2)
     private Integer shelterBusinessFile;  // 민간유(2)

--- a/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
+++ b/care/src/main/java/com/animal/api/signup/model/request/UserSignupRequestDTO.java
@@ -16,45 +16,47 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserSignupRequestDTO {
 
-	@NotBlank(message = "아이디는 필수 입력 항목입니다")
-	@Pattern(regexp = "^[a-z0-9]{6,20}$", message = "아이디는 영문 소문자와 숫자 조합으로 6~20자 이내여야 합니다")
+    @NotBlank(message = "아이디는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^[a-z0-9]{6,20}$", message = "아이디는 영문 소문자와 숫자 조합으로 6~20자 이내여야 합니다.")
     private String id;
-	
-	@NotBlank(message = "이메일은 필수 입력 항목 입니다")
-	@Email(message = "올바른 이메일 형식이 아닙니다")
+
+    @NotBlank(message = "이메일은 필수 입력 항목입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
-	
-	@NotBlank(message = "비밀번호는 필수 입력 항목입니다")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{9,20}$", 
-    message = "비밀번호는 공백 없이 영문, 숫자, 특수문자를 포함하여 9~20자 이내여야 합니다.")
+
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Pattern(
+        regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{9,20}$",
+        message = "비밀번호는 공백 없이 영문, 숫자, 특수문자를 포함하여 9~20자 이내여야 합니다."
+    )
     private String password;
 
     @NotBlank(message = "이름은 필수 항목입니다.")
     @Pattern(regexp = "^[가-힣]{2,5}$", message = "이름은 한글 2~5자여야 합니다.")
     private String name;
-    
+
     @NotBlank(message = "닉네임은 필수 항목입니다.")
     @Pattern(regexp = "^[a-zA-Z0-9가-힣]{2,20}$", message = "닉네임은 특수문자 없이 2~20자 이내여야 합니다.")
     private String nickname;
 
-    @NotNull(message = "생년월일은 필수 항목입니다.")  
+    @NotNull(message = "생년월일은 필수 항목입니다.")
     private LocalDate birthDate;
-    
+
     @NotBlank(message = "성별은 필수 항목입니다.")
-    @Pattern(regexp = "^[MF]$", message = "성별은 남성 또는 여성이야 합니다.")   
-    private String gender; // 'M' or 'F'
-    
-    @NotNull(message = "전화번호는 필수 항목입니다.")
-    @Pattern(regexp = "^\\d{9,20}$", message = "전화번호는 숫자만 입력해야 합니다.")  
+    @Pattern(regexp = "^[MF]$", message = "성별은 M 또는 F여야 합니다.")
+    private String gender;
+
+    @NotBlank(message = "전화번호는 필수 항목입니다.")
+    @Pattern(regexp = "^\\d{9,20}$", message = "전화번호는 숫자만 입력하며 9~20자 이내여야 합니다.")
     private String tel;
 
     @NotNull(message = "우편번호는 필수 항목입니다.")
     private Integer zipCode;
-    
+
     @NotBlank(message = "주소는 필수 항목입니다.")
     private String address;
-    
-    @NotBlank(message = "상세 주소는 필수 항목 입니다")
+
+    @NotBlank(message = "상세 주소는 필수 항목입니다.")
     private String addressDetail;
 
 }

--- a/care/src/main/java/com/animal/api/signup/service/ShelterSignupService.java
+++ b/care/src/main/java/com/animal/api/signup/service/ShelterSignupService.java
@@ -1,11 +1,8 @@
 package com.animal.api.signup.service;
 
 import com.animal.api.signup.model.request.ShelterSignupRequestDTO;
-import com.animal.api.signup.model.request.UserSignupRequestDTO;
 
-public interface SignupService {
+public interface ShelterSignupService {
 
-	void signupUser(UserSignupRequestDTO dto);
-	
 	void signupShelter(ShelterSignupRequestDTO dto);
 }

--- a/care/src/main/java/com/animal/api/signup/service/ShelterSignupServiceImple.java
+++ b/care/src/main/java/com/animal/api/signup/service/ShelterSignupServiceImple.java
@@ -41,9 +41,12 @@ public class ShelterSignupServiceImple implements ShelterSignupService {
 	    // 2. [SHELTERS] 관련 유효성 검사 (선택 사항: email 도메인, 사업자번호 포맷 등)
 	    switch(dto.getShelterTypeIdx()) {
 	    	case 1: 
-	    		if(dto.getShelterEmail() == null || !dto.getShelterEmail().matches(".*@(go\\.kr|korea\\.kr|or\\.kr|kr)$")) {
-	    			throw new CustomException(400, "공공 보호소는 go.kr, korea.kr, or.kr 도메인의 이메일이 필요합니다");
-	            }
+	    		if (dto.getShelterEmail() == null || !dto.getShelterEmail().matches(
+	    			    "^[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\\.)?(go\\.kr|korea\\.kr|or\\.kr)$"
+	    			)) {
+	    			    throw new CustomException(400, 
+	    			        "공공 보호소는 go.kr, korea.kr, or.kr 도메인의 이메일이 필요합니다");
+	    			}
 	            if (dto.getShelterBusinessNumber() == null || dto.getShelterBusinessNumber().isBlank()) {
 	                throw new CustomException(400, "공공 보호소는 사업자등록번호가 필요합니다");
 	            }

--- a/care/src/main/java/com/animal/api/signup/service/ShelterSignupServiceImple.java
+++ b/care/src/main/java/com/animal/api/signup/service/ShelterSignupServiceImple.java
@@ -11,11 +11,10 @@ import com.animal.api.auth.model.vo.ShelterVO;
 import com.animal.api.auth.model.vo.UserVO;
 import com.animal.api.signup.mapper.SignupMapper;
 import com.animal.api.signup.model.request.ShelterSignupRequestDTO;
-import com.animal.api.signup.model.request.UserSignupRequestDTO;
 
 @Service
 @Primary
-public class SignupServiceImple implements SignupService {
+public class ShelterSignupServiceImple implements ShelterSignupService {
 
 	@Autowired
 	private SignupMapper signupMapper;
@@ -23,48 +22,12 @@ public class SignupServiceImple implements SignupService {
 	@Autowired
 	private BCryptPasswordEncoder passwordEncoder;
 
-	//일반 사용자 회원가입 Service
-	@Override
-	public void signupUser(UserSignupRequestDTO dto) {
-
-		// 1. 중복 검사
-		if (signupMapper.isDuplicateId(dto.getId()) > 0) {
-			throw new CustomException(409, "이미 사용 중인 아이디입니다.");
-		}
-
-		if (signupMapper.isDuplicateEmail(dto.getEmail()) > 0) {
-			throw new CustomException(409, "이미 가입된 이메일 입니다.");
-		}
-
-		if (signupMapper.isDuplicateNickname(dto.getNickname()) > 0) {
-			throw new CustomException(409, "이미 사용 중인 닉네임입니다.");
-		}
-
-		// 2. DTO -> VO 매핑
-		UserVO user = new UserVO();
-		user.setUserTypeIdx(1); // 일반 사용자
-		user.setId(dto.getId());
-		user.setEmail(dto.getEmail());
-		user.setPassword(passwordEncoder.encode(dto.getPassword())); // 암호화
-		user.setName(dto.getName());
-		user.setNickname(dto.getNickname());
-		user.setBirthDate(dto.getBirthDate());
-		user.setGender(dto.getGender());
-		user.setTel(dto.getTel());
-		user.setZipCode(dto.getZipCode());
-		user.setAddress(dto.getAddress());
-		user.setAddressDetail(dto.getAddressDetail());
-
-		// 3. DB 저장
-		signupMapper.insertUser(user);
-	}
-	
 	//보호시설 사용자 회원가입 Service
 	@Override
 	@Transactional(rollbackFor = Exception.class)
 	public void signupShelter(ShelterSignupRequestDTO dto) {
 
-	    // 1. 중복 체크
+	    // 1. [USERS] 관련 유효성 검사
 	    if (signupMapper.isDuplicateId(dto.getId()) > 0) {
 	        throw new CustomException(409, "이미 사용 중인 아이디입니다.");
 	    }
@@ -75,25 +38,7 @@ public class SignupServiceImple implements SignupService {
 	        throw new CustomException(409, "이미 사용 중인 닉네임입니다.");
 	    }
 
-	    // 2. USER VO 생성
-	    UserVO user = new UserVO();
-	    user.setUserTypeIdx(2); // 보호시설 고정
-	    user.setId(dto.getId());
-	    user.setEmail(dto.getEmail());
-	    user.setPassword(passwordEncoder.encode(dto.getPassword()));
-	    user.setName(dto.getName());
-	    user.setNickname(dto.getNickname());
-	    user.setBirthDate(dto.getBirthDate());
-	    user.setGender(dto.getGender());
-	    user.setTel(dto.getTel());
-	    user.setZipCode(dto.getZipCode());
-	    user.setAddress(dto.getAddress());
-	    user.setAddressDetail(dto.getAddressDetail());
-	    user.setStatus(0); // **관리자 승인 대기 상태
-
-	    // 3. USERS 테이블에 insert
-	    signupMapper.insertUser(user);
-	    
+	    // 2. [SHELTERS] 관련 유효성 검사 (선택 사항: email 도메인, 사업자번호 포맷 등)
 	    switch(dto.getShelterTypeIdx()) {
 	    	case 1: 
 	    		if(dto.getShelterEmail() == null || !dto.getShelterEmail().matches(".*@(go\\.kr|korea\\.kr|or\\.kr|kr)$")) {
@@ -118,7 +63,25 @@ public class SignupServiceImple implements SignupService {
 	    	default: 
 	    		throw new CustomException(400, "올바르지 않은 보호시설 유형입니다.");
 	    }
+	    // 3. USER VO 생성
+	    UserVO user = new UserVO();
+	    user.setUserTypeIdx(2); // 보호시설 고정
+	    user.setId(dto.getId());
+	    user.setEmail(dto.getEmail());
+	    user.setPassword(passwordEncoder.encode(dto.getPassword()));
+	    user.setName(dto.getName());
+	    user.setNickname(dto.getNickname());
+	    user.setBirthDate(dto.getBirthDate());
+	    user.setGender(dto.getGender());
+	    user.setTel(dto.getTel());
+	    user.setZipCode(dto.getZipCode());
+	    user.setAddress(dto.getAddress());
+	    user.setAddressDetail(dto.getAddressDetail());
+	    user.setStatus(0); // **관리자 승인 대기 상태
 
+	    // 3. USERS 테이블에 insert
+	    signupMapper.insertUser(user);
+	    
 	    // 4. SHELTER VO 생성
 	    ShelterVO shelter = new ShelterVO();
 	    shelter.setUserIdx(user.getIdx()); // 방금 insert된 사용자 PK

--- a/care/src/main/java/com/animal/api/signup/service/UserSignupService.java
+++ b/care/src/main/java/com/animal/api/signup/service/UserSignupService.java
@@ -1,0 +1,8 @@
+package com.animal.api.signup.service;
+
+import com.animal.api.signup.model.request.UserSignupRequestDTO;
+
+public interface UserSignupService {
+
+    void signupUser(UserSignupRequestDTO dto);
+}

--- a/care/src/main/java/com/animal/api/signup/service/UserSignupServiceImple.java
+++ b/care/src/main/java/com/animal/api/signup/service/UserSignupServiceImple.java
@@ -1,0 +1,51 @@
+package com.animal.api.signup.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import com.animal.api.auth.exception.CustomException;
+import com.animal.api.auth.model.vo.UserVO;
+import com.animal.api.signup.mapper.SignupMapper;
+import com.animal.api.signup.model.request.UserSignupRequestDTO;
+
+public class UserSignupServiceImple implements UserSignupService {
+    @Autowired
+    private SignupMapper signupMapper;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+	@Override
+	public void signupUser(UserSignupRequestDTO dto) {
+		// 1. 중복 검사
+		if (signupMapper.isDuplicateId(dto.getId()) > 0) {
+			throw new CustomException(409, "이미 사용 중인 아이디입니다.");
+		}
+
+		if (signupMapper.isDuplicateEmail(dto.getEmail()) > 0) {
+			throw new CustomException(409, "이미 가입된 이메일 입니다.");
+		}
+
+		if (signupMapper.isDuplicateNickname(dto.getNickname()) > 0) {
+			throw new CustomException(409, "이미 사용 중인 닉네임입니다.");
+		}
+
+		// 2. DTO -> VO 매핑
+		UserVO user = new UserVO();
+		user.setUserTypeIdx(1); // 일반 사용자
+		user.setId(dto.getId());
+		user.setEmail(dto.getEmail());
+		user.setPassword(passwordEncoder.encode(dto.getPassword())); // 암호화
+		user.setName(dto.getName());
+		user.setNickname(dto.getNickname());
+		user.setBirthDate(dto.getBirthDate());
+		user.setGender(dto.getGender());
+		user.setTel(dto.getTel());
+		user.setZipCode(dto.getZipCode());
+		user.setAddress(dto.getAddress());
+		user.setAddressDetail(dto.getAddressDetail());
+
+		// 3. DB 저장
+		signupMapper.insertUser(user);
+	}
+
+}

--- a/care/src/main/java/com/animal/api/signup/service/UserSignupServiceImple.java
+++ b/care/src/main/java/com/animal/api/signup/service/UserSignupServiceImple.java
@@ -1,13 +1,17 @@
 package com.animal.api.signup.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
 
 import com.animal.api.auth.exception.CustomException;
 import com.animal.api.auth.model.vo.UserVO;
 import com.animal.api.signup.mapper.SignupMapper;
 import com.animal.api.signup.model.request.UserSignupRequestDTO;
 
+@Service
+@Primary
 public class UserSignupServiceImple implements UserSignupService {
     @Autowired
     private SignupMapper signupMapper;
@@ -43,6 +47,7 @@ public class UserSignupServiceImple implements UserSignupService {
 		user.setZipCode(dto.getZipCode());
 		user.setAddress(dto.getAddress());
 		user.setAddressDetail(dto.getAddressDetail());
+		user.setStatus(1);
 
 		// 3. DB 저장
 		signupMapper.insertUser(user);

--- a/care/src/main/resources/mybatis-config.xml
+++ b/care/src/main/resources/mybatis-config.xml
@@ -10,16 +10,4 @@
 		<setting name="mapUnderscoreToCamelCase" value="true"/>
 	</settings>
 
-	<environments default="dev">
-		<environment id="dev">
-			<transactionManager type="JDBC" />
-			<dataSource type="UNPOOLED">
-				<property name="driver" value="dummy" />
-				<property name="url" value="dummy" />
-				<property name="username" value="dummy" />
-				<property name="password" value="dummy" />
-			</dataSource>
-		</environment>
-	</environments>
-
 </configuration>

--- a/care/src/main/resources/sql-mapper/signup/SignupMapper.xml
+++ b/care/src/main/resources/sql-mapper/signup/SignupMapper.xml
@@ -20,16 +20,20 @@
 	</select>
 
 	<!-- 4. 일반 사용자 회원가입 -->
-	<insert id="insertUser" parameterType="com.animal.api.auth.model.vo.UserVO"
-		useGeneratedKeys="true" keyProperty="idx">
+	<insert id="insertUser" parameterType="com.animal.api.auth.model.vo.UserVO">
+		<!-- INSERT 후 자동 증가된 PK를 VO의 idx 필드에 설정 -->
+		<selectKey keyProperty="idx" resultType="int" order="AFTER">
+			SELECT LAST_INSERT_ID()
+		</selectKey>
+		
 		INSERT INTO USERS (
-		USER_TYPE_IDX, ID, EMAIL, PASSWORD,
-		NAME, NICKNAME, BIRTH_DATE, GENDER, TEL,
-		ZIP_CODE, ADDRESS, ADDRESS_DETAIL
+			USER_TYPE_IDX, ID, EMAIL, PASSWORD,
+			NAME, NICKNAME, BIRTH_DATE, GENDER, TEL,
+			ZIP_CODE, ADDRESS, ADDRESS_DETAIL
 		) VALUES (
-		#{userTypeIdx}, #{id}, #{email}, #{password},
-		#{name}, #{nickname}, #{birthDate}, #{gender}, #{tel},
-		#{zipCode}, #{address}, #{addressDetail}
+			#{userTypeIdx}, #{id}, #{email}, #{password},
+			#{name}, #{nickname}, #{birthDate}, #{gender}, #{tel},
+			#{zipCode}, #{address}, #{addressDetail}
 		)
 	</insert>
 

--- a/care/src/main/resources/sql-mapper/signup/SignupMapper.xml
+++ b/care/src/main/resources/sql-mapper/signup/SignupMapper.xml
@@ -29,11 +29,11 @@
 		INSERT INTO USERS (
 			USER_TYPE_IDX, ID, EMAIL, PASSWORD,
 			NAME, NICKNAME, BIRTH_DATE, GENDER, TEL,
-			ZIP_CODE, ADDRESS, ADDRESS_DETAIL
+			ZIP_CODE, ADDRESS, ADDRESS_DETAIL, STATUS
 		) VALUES (
 			#{userTypeIdx}, #{id}, #{email}, #{password},
 			#{name}, #{nickname}, #{birthDate}, #{gender}, #{tel},
-			#{zipCode}, #{address}, #{addressDetail}
+			#{zipCode}, #{address}, #{addressDetail},#{status}
 		)
 	</insert>
 

--- a/care/src/main/webapp/WEB-INF/spring/applicationContext.xml
+++ b/care/src/main/webapp/WEB-INF/spring/applicationContext.xml
@@ -62,7 +62,13 @@
 
 	<!-- ✅ MyBatis Mapper 자동 등록 (XML + 인터페이스 연결) -->
 	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-		<property name="basePackage" value="com.animal.api.**" />
+		<property name="basePackage" value="com.animal.api" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSessionFactory"/>
+	</bean>
+	
+	<!-- ✅ SqlSessionTemplate 등록 -->
+	<bean id="sqlSession" class="org.mybatis.spring.SqlSessionTemplate">
+	    <constructor-arg index="0" ref="sqlSessionFactory"/>
 	</bean>
 
 	<!-- ✅ 트랜잭션 매니저: DB 트랜잭션 처리용 -->


### PR DESCRIPTION
보호 시설 회원 가입 시 보호시설 입력 정보가 틀렸음에도 USERS 테이블에 데이터 저장이 되는 문제 -> 유저 먼저 유효성 검사 후 INSERT 하고 보호소 검사 후 보호시설 INSERT 방식 에서의 문제 파악 -> 유저 정보 + 보호시설 정보 모두 유효성 검사 통과 후 트랜잭션 INSERT 로직으로 변경 완료  및 일반 유저 구현체 , 보호시설 구현체 분리

- 유형에 따른 로그인 제한 수정 
- GlobalExceptionHandler 에서 에러message 만 나올 수 있도록 수정 

![image](https://github.com/user-attachments/assets/67f3da65-c463-4863-a7a8-bde86734fea9)
