### PR TITLE
[PR]Feature/get adoption request list

### DIFF
--- a/care/src/main/java/com/animal/api/animal/controller/UserAnimalController.java
+++ b/care/src/main/java/com/animal/api/animal/controller/UserAnimalController.java
@@ -152,14 +152,16 @@ public class UserAnimalController {
 		if (loginUser == null) {
 			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
 		}
-
+		dto.setUserIdx(loginUser.getIdx());
 		int result = service.submitAdoption(dto);
 
 		if (result == service.RESERVATION_COMPLETED) {
 			return ResponseEntity.status(HttpStatus.CREATED).body(new OkResponseDTO<Void>(201, "입양 상담 신청 성공", null));
 		} else if (result == service.RESERVATION_UNAVAILABLE) {
 			return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponseDTO(409, "입양 상담 신청 가능 상태가 아닙니다."));
-		} else {
+		} else if(result == service.RESERVATION_DUPLICATE) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(new ErrorResponseDTO(409, "이미 상담을 신청하였습니다."));
+		}else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 접근입니다."));
 		}
 	}

--- a/care/src/main/java/com/animal/api/animal/mapper/UserAnimalMapper.java
+++ b/care/src/main/java/com/animal/api/animal/mapper/UserAnimalMapper.java
@@ -21,7 +21,9 @@ public interface UserAnimalMapper {
 
 	public AdoptionAnimalResponseDTO getAdoptionInfo(int idx);
 
-	public String checkAdoptionStatus(int idx);
+	public Integer checkAdoptionStatus(int idx);
+	
+	public Integer checkDuplicateUser(Map map);
 
 	public int submitAdoption(AdoptionSubmitReqestDTO dto);
 

--- a/care/src/main/java/com/animal/api/animal/model/request/AdoptionSubmitReqestDTO.java
+++ b/care/src/main/java/com/animal/api/animal/model/request/AdoptionSubmitReqestDTO.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AdoptionSubmitReqestDTO {
-    @NotNull(message = "유저 번호는 필수입니다.")
+	// 유저 번호는 로그인 정보로 대체
     private Integer userIdx;
 
     @NotNull(message = "동물 번호는 필수입니다.")

--- a/care/src/main/java/com/animal/api/animal/service/UserAnimalService.java
+++ b/care/src/main/java/com/animal/api/animal/service/UserAnimalService.java
@@ -10,6 +10,7 @@ import com.animal.api.animal.model.response.AnimalDetailResponseDTO;
 public interface UserAnimalService {
 
 	static int RESERVATION_COMPLETED = 1; // 예약 신청 완료
+	static int RESERVATION_DUPLICATE = 2; // 예약 신청 완료
 	static int RESERVATION_UNAVAILABLE = 0; // 예약 불가능
 	static int RESERVATION_FAILD = -1; // 에러
 

--- a/care/src/main/java/com/animal/api/animal/service/UserAnimalServiceImple.java
+++ b/care/src/main/java/com/animal/api/animal/service/UserAnimalServiceImple.java
@@ -85,17 +85,23 @@ public class UserAnimalServiceImple implements UserAnimalService {
 
 	@Override
 	public int submitAdoption(AdoptionSubmitReqestDTO dto) {
-		String checkStatusString = mapper.checkAdoptionStatus(dto.getAnimalIdx());
-		int checkStatus = 0;
-
-		if (checkStatusString != null) {
-			checkStatus = Integer.parseInt(checkStatusString);
-		} else {
+		// 입양 가능 상태 검사
+		Integer checkStatus = mapper.checkAdoptionStatus(dto.getAnimalIdx());
+		if (checkStatus == null) {
 			return RESERVATION_FAILD;
 		}
 
 		if (checkStatus != 1) {
 			return RESERVATION_UNAVAILABLE;
+		}
+		Map<String, Integer> map = new HashMap<String, Integer>();
+
+		// 중복 신청 검사
+		map.put("userIdx", dto.getUserIdx());
+		map.put("animalIdx", dto.getAnimalIdx());
+		Integer checkDuplicate = mapper.checkDuplicateUser(map);
+		if (checkDuplicate != null) {
+			return RESERVATION_DUPLICATE;
 		}
 
 		int result = mapper.submitAdoption(dto);

--- a/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
+++ b/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
@@ -1,6 +1,7 @@
 package com.animal.api.management.animal.controller;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpSession;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -24,6 +26,7 @@ import com.animal.api.common.model.ErrorResponseDTO;
 import com.animal.api.common.model.OkResponseDTO;
 import com.animal.api.management.animal.model.request.AnimalInsertRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO;
+import com.animal.api.management.animal.model.response.AdoptionConsultListResponseDTO;
 import com.animal.api.management.animal.model.response.AnimalAddShelterInfoResponseDTO;
 import com.animal.api.management.animal.service.ShelterAnimalsService;
 
@@ -105,8 +108,9 @@ public class ShelterAnimalsController {
 
 	/**
 	 * 유기동물 이미지 업로드 메서드
+	 * 
 	 * @param files 프론트 영역에서 받은 유기동물 이미지
-	 * @param idx 유기동물이 생성되면서 생긴 관리번호
+	 * @param idx   유기동물이 생성되면서 생긴 관리번호
 	 * @return 파일 업로드 성공 또는 실패
 	 */
 	@PostMapping("/upload/{idx}")
@@ -196,6 +200,34 @@ public class ShelterAnimalsController {
 			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "유기동물 삭제 성공", null));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "유기동물 삭제 실패"));
+		}
+	}
+
+	@GetMapping("/adoptions")
+	public ResponseEntity<?> getAdoptionConsultList(@RequestParam(value = "cp", defaultValue = "0") int cp,
+			HttpSession session) {
+		LoginResponseDTO loginUser = (LoginResponseDTO) session.getAttribute("loginUser");
+
+		if (loginUser == null) { // 로그인 여부 검증
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		if (loginUser.getUserTypeIdx() != 2) { // 보호시설 회원 검증
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "보호시설 회원만 접근 가능합니다."));
+		}
+
+		int listSize = 3;
+
+		List<AdoptionConsultListResponseDTO> consultList = service.getAdoptionConsultList(loginUser.getIdx(), listSize,
+				cp);
+
+		if (consultList == null) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 요청 입니다."));
+		} else if (consultList.size() == 0) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "조회된 데이터가 없습니다."));
+		} else {
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new OkResponseDTO<List<AdoptionConsultListResponseDTO>>(200, "조회 성공", consultList));
 		}
 	}
 

--- a/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
+++ b/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
@@ -38,6 +38,7 @@ import com.animal.api.management.animal.service.ShelterAnimalsService;
  * @see com.animal.api.management.animal.model.response.AnimalAddShelterInfoResponseDTO
  * @see com.animal.api.management.animal.model.request.AnimalInsertRequestDTO
  * @see com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO
+ * @see com.animal.api.management.animal.model.response.AdoptionConsultListResponseDTO
  */
 
 @RestController
@@ -203,6 +204,12 @@ public class ShelterAnimalsController {
 		}
 	}
 
+	/**
+	 * 해당 보호시설의 입양 신청 내역 리스트를 조회하는 메서드
+	 * @param cp 현재 페이지
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 입양 상담 신청내역 리스트
+	 */
 	@GetMapping("/adoptions")
 	public ResponseEntity<?> getAdoptionConsultList(@RequestParam(value = "cp", defaultValue = "0") int cp,
 			HttpSession session) {

--- a/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
+++ b/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
@@ -1,9 +1,12 @@
 package com.animal.api.management.animal.mapper;
 
+import java.util.Map;
+
 import org.apache.ibatis.annotations.Mapper;
 
 import com.animal.api.management.animal.model.request.AnimalInsertRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO;
+import com.animal.api.management.animal.model.response.AdoptionConsultListResponseDTO;
 import com.animal.api.management.animal.model.response.AnimalAddShelterInfoResponseDTO;
 
 @Mapper
@@ -20,5 +23,7 @@ public interface ShelterAnimalsMapper {
 	public Integer getAnimalShelter(int idx);
 	
 	public Integer getAnimalMaxIdx();
+	
+	public AdoptionConsultListResponseDTO getAdoptionConsultList(Map map);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
+++ b/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
@@ -1,5 +1,6 @@
 package com.animal.api.management.animal.mapper;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -24,6 +25,6 @@ public interface ShelterAnimalsMapper {
 	
 	public Integer getAnimalMaxIdx();
 	
-	public AdoptionConsultListResponseDTO getAdoptionConsultList(Map map);
+	public List<AdoptionConsultListResponseDTO> getAdoptionConsultList(Map map);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/model/response/AdoptionConsultListResponseDTO.java
+++ b/care/src/main/java/com/animal/api/management/animal/model/response/AdoptionConsultListResponseDTO.java
@@ -1,0 +1,26 @@
+package com.animal.api.management.animal.model.response;
+
+import java.sql.Timestamp;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdoptionConsultListResponseDTO {
+	private int idx;
+	private int userIdx;
+	private String animalName;
+	private String name;
+	private String tel;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	private Timestamp consultedAt;
+	private int statusIdx;
+	private String status;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	private Timestamp createdAt;
+}

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
@@ -1,9 +1,12 @@
 package com.animal.api.management.animal.service;
 
+import java.util.List;
+
 import org.springframework.web.multipart.MultipartFile;
 
 import com.animal.api.management.animal.model.request.AnimalInsertRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO;
+import com.animal.api.management.animal.model.response.AdoptionConsultListResponseDTO;
 import com.animal.api.management.animal.model.response.AnimalAddShelterInfoResponseDTO;
 
 public interface ShelterAnimalsService {
@@ -26,5 +29,7 @@ public interface ShelterAnimalsService {
 	public int getAnimalShelter(int idx);
 
 	public int uploadAnimalImage(MultipartFile[] files, int idx);
+
+	public List<AdoptionConsultListResponseDTO> getAdoptionConsultList(int idx, int listSize, int cp);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
@@ -1,5 +1,9 @@
 package com.animal.api.management.animal.service;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
@@ -9,6 +13,7 @@ import com.animal.api.common.util.FileManager;
 import com.animal.api.management.animal.mapper.ShelterAnimalsMapper;
 import com.animal.api.management.animal.model.request.AnimalInsertRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO;
+import com.animal.api.management.animal.model.response.AdoptionConsultListResponseDTO;
 import com.animal.api.management.animal.model.response.AnimalAddShelterInfoResponseDTO;
 
 @Service
@@ -47,11 +52,11 @@ public class ShelterAnimalsServiceImple implements ShelterAnimalsService {
 		int result = mapper.deleteAnimal(idx);
 
 		result = result > 0 ? DELETE_SUCCESS : ERROR;
-		
-		if(result == DELETE_SUCCESS) {
+
+		if (result == DELETE_SUCCESS) {
 			fileManager.deleteFolder("animals", idx);
 		}
-		
+
 		return result;
 	}
 
@@ -77,5 +82,29 @@ public class ShelterAnimalsServiceImple implements ShelterAnimalsService {
 			mapper.deleteAnimal(idx);
 			return ERROR;
 		}
+	}
+
+	@Override
+	public List<AdoptionConsultListResponseDTO> getAdoptionConsultList(int idx, int listSize, int cp) {
+		cp = changeCurrentPage(cp, listSize);
+
+		Map<String, Integer> map = new HashMap<String, Integer>();
+		map.put("idx", idx);
+		map.put("listSize", listSize);
+		map.put("cp", cp);
+
+		List<AdoptionConsultListResponseDTO> consultList = mapper.getAdoptionConsultList(map);
+
+		return consultList;
+	}
+
+	// 넘어온 페이지를 쿼리에 넣을 수 있게 가공하는 메서드
+	public int changeCurrentPage(int cp, int listSize) {
+		if (cp == 0) {
+			cp = 1;
+		}
+		cp = (cp - 1) * listSize;
+
+		return cp;
 	}
 }

--- a/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
+++ b/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
@@ -79,4 +79,32 @@ FROM
 WHERE
 	IDX = #{idx}
 </select>
+<select id="getAdoptionConsultList" parameterType="Map" resultType="com.animal.api.management.animal.model.response.AdoptionConsultListResponseDTO">
+SELECT
+	AC.IDX,
+	U.IDX AS 'USER_IDX',
+	A.NAME AS 'ANIMAL_NAME',
+	AC.NAME,
+	AC.TEL,
+	AC.CONSULTED_AT,
+	ACS.IDX AS 'STATUS_IDX',
+	ACS.NAME AS 'STATUS',
+	AC.CREATED_AT
+FROM
+	ADOPTION_CONSULTS AC
+JOIN ANIMALS A
+ON
+	AC.ANIMAL_IDX = A.IDX
+JOIN USERS U 
+ON
+	AC.USER_IDX = U.IDX
+JOIN ADOPTION_CONSULT_STATUS ACS 
+ON
+	AC.ADOPTION_CONSULT_STATUS_IDX = ACS.IDX
+WHERE
+	A.USER_IDX = #{idx}
+ORDER BY
+	AC.IDX DESC
+LIMIT #{listSize} OFFSET #{cp}
+</select>
 </mapper>

--- a/care/src/main/resources/sql-mapper/animal/UserAnimalMapper.xml
+++ b/care/src/main/resources/sql-mapper/animal/UserAnimalMapper.xml
@@ -173,13 +173,22 @@ JOIN SHELTERS S
 WHERE
 	A.IDX = #{idx}
 </select>
-<select id="checkAdoptionStatus" parameterType="int" resultType="String">
+<select id="checkAdoptionStatus" parameterType="int" resultType="Integer">
 SELECT
 	ADOPTION_STATUS_IDX
 FROM
 	ANIMALS
 WHERE
 	IDX = #{idx}
+</select>
+<select id="checkDuplicateUser" parameterType="Map" resultType="Integer">
+SELECT
+	IDX
+FROM
+	ADOPTION_CONSULTS
+WHERE
+	USER_IDX = #{userIdx}
+	AND ANIMAL_IDX = #{animalIdx}
 </select>
 <insert id="submitAdoption" parameterType="com.animal.api.animal.model.request.AdoptionSubmitReqestDTO">
 INSERT


### PR DESCRIPTION
보호시설 관리 페이지에서 해당 보호소의 입양 상담 신청 내역을 조회하는 메서드
- 로그인 여부 검증
- 보호시설 권한 검증
- 데이터 유무 검증
- 추가로 입양 상담 신청 시 중복 신청 안되도록 수정

엔드포인트 : api/management/animals/adoptions

로그인 검증 실패(401)
![image](https://github.com/user-attachments/assets/91a0ae02-4437-4fa7-b69f-fc270394eb08)

권한 검증 실패(403)
![image](https://github.com/user-attachments/assets/3f3522dc-ec8a-4ffb-a2fe-366972e65905)

데이터 없음(404)
![image](https://github.com/user-attachments/assets/14295951-c789-4538-b46e-926049e17540)

조회 성공(200)
![image](https://github.com/user-attachments/assets/abd00f3b-5ba7-4c51-8b63-a179616ec616)

입양상담 신청 중복(409)
![image](https://github.com/user-attachments/assets/97b7f51d-8b60-4e25-bb60-c423965d78e7)
