### PR TITLE
[PR]Feature/search user board list

### DIFF
--- a/care/src/main/java/com/animal/api/board/controller/UserBoardController.java
+++ b/care/src/main/java/com/animal/api/board/controller/UserBoardController.java
@@ -19,6 +19,7 @@ import com.animal.api.common.model.OkResponseDTO;
  * @author consgary
  * @since 2025.06.23
  * @see com.animal.api.board.model.response.AllBoardListResponseDTO
+ * @see com.animal.api.board.model.request.BoardSearchRequestDTO
  */
 @RestController
 @RequestMapping("/api/boards")
@@ -28,10 +29,12 @@ public class UserBoardController {
 	private UserBoardService service;
 
 	/**
-	 * 자유게시판 전체 조회
+	 * 전체 게시판 검색 , 조건(제목,닉네임,본문,전체) 검색
 	 * 
-	 * @param cp 현재 페이지
-	 * @return 게시판 전체 리스트
+	 * @param cp      현재 페이지
+	 * @param type    검색 조건
+	 * @param keyword 검색어
+	 * @return 전체 검색 게시판 리스트 or 조건 검색 게시판 리스트
 	 */
 	@GetMapping
 	public ResponseEntity<?> getBoards(@RequestParam(value = "cp", defaultValue = "0") int cp,

--- a/care/src/main/java/com/animal/api/board/controller/UserBoardController.java
+++ b/care/src/main/java/com/animal/api/board/controller/UserBoardController.java
@@ -34,17 +34,25 @@ public class UserBoardController {
 	 * @return 게시판 전체 리스트
 	 */
 	@GetMapping
-	public ResponseEntity<?> getBoards(@RequestParam(value = "cp", defaultValue = "0") int cp) {
+	public ResponseEntity<?> getBoards(@RequestParam(value = "cp", defaultValue = "0") int cp,
+			@RequestParam(value = "type", required = false) String type,
+			@RequestParam(value = "keyword", required = false) String keyword) {
 		int listSize = 3;
-		List<AllBoardListResponseDTO> boardList = service.getAllBoards(listSize, cp);
+		List<AllBoardListResponseDTO> boardList = null;
+		if (type != null || keyword != null) {
+			boardList = service.searchBoards(type, keyword, listSize, cp);
+		} else {
+			boardList = service.getAllBoards(listSize, cp);
 
+		}
 		if (boardList == null) {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 요청"));
 		} else if (boardList.size() == 0) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "데이터가 존재하지않음"));
 		} else {
 			return ResponseEntity.status(HttpStatus.OK)
-					.body(new OkResponseDTO<List<AllBoardListResponseDTO>>(200, "게시판 전체 조회 성공", boardList));
+					.body(new OkResponseDTO<List<AllBoardListResponseDTO>>(200, "게시판 조회 성공", boardList));
 		}
 	}
+
 }

--- a/care/src/main/java/com/animal/api/board/mapper/UserBoardMapper.java
+++ b/care/src/main/java/com/animal/api/board/mapper/UserBoardMapper.java
@@ -5,9 +5,12 @@ import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.animal.api.board.model.request.BoardSearchRequestDTO;
 import com.animal.api.board.model.response.AllBoardListResponseDTO;
 
 @Mapper
 public interface UserBoardMapper {
 	public List<AllBoardListResponseDTO> getAllBoards(Map map);
+
+	public List<AllBoardListResponseDTO> searchBoards(BoardSearchRequestDTO dto);
 }

--- a/care/src/main/java/com/animal/api/board/model/request/BoardSearchRequestDTO.java
+++ b/care/src/main/java/com/animal/api/board/model/request/BoardSearchRequestDTO.java
@@ -1,0 +1,23 @@
+package com.animal.api.board.model.request;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardSearchRequestDTO {
+	private String type;
+	private String keyword;
+	@NotNull(message = "보여줄 게시글수는 필수 입니다.")
+	@Positive(message = "보여줄 게시글수는 양수만 가능합니다.")
+	private Integer listSize;
+	@NotNull(message = "현재 페이지 번호는 필수 입니다.")
+	@Positive(message = "현재 페이지 번호는 양수만 가능합니다.")
+	private Integer cp;
+
+}

--- a/care/src/main/java/com/animal/api/board/model/request/BoardSearchRequestDTO.java
+++ b/care/src/main/java/com/animal/api/board/model/request/BoardSearchRequestDTO.java
@@ -1,8 +1,5 @@
 package com.animal.api.board.model.request;
 
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,11 +10,7 @@ import lombok.NoArgsConstructor;
 public class BoardSearchRequestDTO {
 	private String type;
 	private String keyword;
-	@NotNull(message = "보여줄 게시글수는 필수 입니다.")
-	@Positive(message = "보여줄 게시글수는 양수만 가능합니다.")
 	private Integer listSize;
-	@NotNull(message = "현재 페이지 번호는 필수 입니다.")
-	@Positive(message = "현재 페이지 번호는 양수만 가능합니다.")
 	private Integer cp;
 
 }

--- a/care/src/main/java/com/animal/api/board/service/UserBoardService.java
+++ b/care/src/main/java/com/animal/api/board/service/UserBoardService.java
@@ -20,4 +20,6 @@ public interface UserBoardService {
 
 	public List<AllBoardListResponseDTO> getAllBoards(int listSize, int cp);
 
+	public List<AllBoardListResponseDTO> searchBoards(String type, String keyword, int listSize, int cp);
+
 }

--- a/care/src/main/java/com/animal/api/board/service/UserBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/board/service/UserBoardServiceImple.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.animal.api.board.mapper.UserBoardMapper;
+import com.animal.api.board.model.request.BoardSearchRequestDTO;
 import com.animal.api.board.model.response.AllBoardListResponseDTO;
 
 @Service
@@ -29,6 +30,19 @@ public class UserBoardServiceImple implements UserBoardService {
 		map.put("listSize", listSize);
 		map.put("cp", cp);
 		List<AllBoardListResponseDTO> boardList = mapper.getAllBoards(map);
+
+		return boardList;
+	}
+
+	@Override
+	public List<AllBoardListResponseDTO> searchBoards(String type, String keyword, int listSize, int cp) {
+		if (cp == 0) {
+			cp = 1;
+		}
+		cp = (cp - 1) * listSize;
+
+		BoardSearchRequestDTO request = new BoardSearchRequestDTO(type, keyword, listSize, cp);
+		List<AllBoardListResponseDTO> boardList = mapper.searchBoards(request);
 
 		return boardList;
 	}

--- a/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
@@ -51,16 +51,16 @@ LEFT JOIN BOARD_LIKES BL ON
 	B.BOARD_TYPE_IDX = 2
 
     <choose>
-        <when test = "type == 'title' AND keyword != NULL AND keyword != ''">
+        <when test = "type == 'title' and keyword != null and keyword != ''">
 			AND B.TITLE LIKE CONCAT('%', #{keyword}, '%')
         </when>
-        <when test = "type == 'nickname' AND keyword != NULL AND keyword != ''">
+        <when test = "type == 'nickname' and keyword != null and keyword != ''">
             AND U.NICKNAME LIKE CONCAT('%', #{keyword}, '%')
         </when>
-        <when test = "type == 'content' AND keyword != NULL AND keyword != ''">
+        <when test = "type == 'content' and keyword != null and keyword != ''">
             AND B.CONTENT LIKE CONCAT('%', #{keyword}, '%')
         </when>
-        <when test = "(type == 'all' OR type == null) AND keyword != NULL AND keyword != ''">
+        <when test = "(type == 'all' or type == null) and keyword != null and keyword != ''">
             AND (
                 B.TITLE LIKE CONCAT('%', #{keyword}, '%')
                 OR U.NICKNAME LIKE CONCAT('%', #{keyword}, '%')

--- a/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
@@ -26,6 +26,54 @@ GROUP BY
 ORDER BY
     B.REF DESC,      
     B.TURN ASC       
-LIMIT #{listSize} OFFSET #{cp};
+LIMIT #{listSize} OFFSET #{cp}
+</select>
+
+<select id="searchBoards" parameterType="com.animal.api.board.model.request.BoardSearchRequestDTO" resultType="com.animal.api.board.model.response.AllBoardListResponseDTO">
+SELECT
+	B.IDX,
+	B.TITLE,
+	IFNULL(U.NICKNAME, '탈퇴 회원') AS NICKNAME,
+	B.CREATED_AT,
+	B.VIEWS,
+	COUNT(BL.IDX) AS LIKE_COUNT,
+	B.REF,
+	B.LEV,
+	B.TURN
+FROM
+	BOARDS B
+LEFT JOIN USERS U ON
+	B.USER_IDX = U.IDX
+LEFT JOIN BOARD_LIKES BL ON
+	B.IDX = BL.BOARD_IDX
+	AND BL.IS_LIKE = 1
+<where>
+	B.BOARD_TYPE_IDX = 2
+
+    <choose>
+        <when test = "type == 'title' AND keyword != NULL AND keyword != ''">
+			AND B.TITLE LIKE CONCAT('%', #{keyword}, '%')
+        </when>
+        <when test = "type == 'nickname' AND keyword != NULL AND keyword != ''">
+            AND U.NICKNAME LIKE CONCAT('%', #{keyword}, '%')
+        </when>
+        <when test = "type == 'content' AND keyword != NULL AND keyword != ''">
+            AND B.CONTENT LIKE CONCAT('%', #{keyword}, '%')
+        </when>
+        <when test = "(type == 'all' OR type == null) AND keyword != NULL AND keyword != ''">
+            AND (
+                B.TITLE LIKE CONCAT('%', #{keyword}, '%')
+                OR U.NICKNAME LIKE CONCAT('%', #{keyword}, '%')
+                OR B.CONTENT LIKE CONCAT('%', #{keyword}, '%')
+            )
+        </when>
+    </choose>
+</where>
+GROUP BY
+    B.IDX, B.TITLE, B.CREATED_AT, B.VIEWS, U.NICKNAME, B.REF, B.LEV, B.TURN
+ORDER BY
+    B.REF DESC,
+    B.TURN ASC
+LIMIT #{listSize} OFFSET #{cp}
 </select>
 </mapper>


### PR DESCRIPTION
게시판 조건별 검색 기능

-조건
전체(제목+글쓴이+본문),제목,글쓴이,본문

**URL:/api/boards?**

수정할 사항
-조건이 유효하지 않을때 전체검색 실행되지 않도록 수정

글쓴이 검색 성공(200)
![조건(닉네임) 검색성공](https://github.com/user-attachments/assets/1f21b0d1-eedf-4e0a-acb0-b3e72ae30436)

본문 검색 성공(200)
![조건(본문)검색 성공](https://github.com/user-attachments/assets/8a41d506-dfec-47ee-9097-b1fc8530a4db)

제목 검색 성공(200)
![조건(제목)검색 성공](https://github.com/user-attachments/assets/91edc4ab-4b73-4476-9500-789ff3c42714)

전체 검색 성공(200)
![조건이 전체일때](https://github.com/user-attachments/assets/2916e93e-4179-4ee1-a6c2-428c94ea951a)


조건은 유효하지만 검색어가 존재 하지 않음(404)
![조건은 해당하나 데이터가 없을때](https://github.com/user-attachments/assets/c70a15d5-118a-41c5-90cb-0dceb3218c27)

조건,검색어가 존재 하지 않을때(200) -> 전체 검색
![조건이 없을때](https://github.com/user-attachments/assets/bea2adf0-b273-4ff9-a413-9638657986b9)

조건이 유효하지 않을때(200) -> 전체검색
![조건이 해당하지 않을때(닉네임,제목,본문](https://github.com/user-attachments/assets/61dcfeec-eea5-4428-ab28-1f458b84916c)


