### PR TITLE
[PR]Feature/update adoption request

### DIFF
--- a/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
+++ b/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
@@ -273,6 +273,14 @@ public class ShelterAnimalsController {
 		}
 	}
 
+	/**
+	 * 해당 보호시설의 입양 상담 신청의 상태를 변경하는 메서드
+	 * 
+	 * @param consultIdx 입양 상담 신청 번호
+	 * @param dto        변경할 상태
+	 * @param session    로그인 검증을 위한 세션
+	 * @return 성공 또는 실패 메세지
+	 */
 	@PutMapping("/adoptions/{consultIdx}")
 	public ResponseEntity<?> updateAdoptionConsultStatus(@PathVariable int consultIdx,
 			@Valid @RequestBody AdoptionConsultStatusRequestDTO dto, HttpSession session) {

--- a/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
+++ b/care/src/main/java/com/animal/api/management/animal/controller/ShelterAnimalsController.java
@@ -273,8 +273,8 @@ public class ShelterAnimalsController {
 		}
 	}
 
-	@PutMapping("/adoptions/{idx}")
-	public ResponseEntity<?> updateAdoptionConsultStatus(@PathVariable int idx,
+	@PutMapping("/adoptions/{consultIdx}")
+	public ResponseEntity<?> updateAdoptionConsultStatus(@PathVariable int consultIdx,
 			@Valid @RequestBody AdoptionConsultStatusRequestDTO dto, HttpSession session) {
 		LoginResponseDTO loginUser = (LoginResponseDTO) session.getAttribute("loginUser");
 
@@ -286,13 +286,16 @@ public class ShelterAnimalsController {
 			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "보호시설 회원만 접근 가능합니다."));
 		}
 
-		int result = service.updateAdoptionConsultStatus(dto, loginUser.getIdx());
+		int result = service.updateAdoptionConsultStatus(dto, loginUser.getIdx(), consultIdx);
 
 		if (result == service.UPDATE_SUCCESS) {
 			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "상태 변경 성공", null));
-		} else if(result == service.NOT_CONSULT){
-			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "해당 보호시설의 상담 신청이 아닙니다."));
-		}else{
+		} else if (result == service.NOT_CONSULT) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "해당 상담 신청을 찾을 수 없습니다."));
+		} else if (result == service.NOT_OWNED_CONSULT) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN)
+					.body(new ErrorResponseDTO(403, "로그인한 보호시설의 상담신청이 아닙니다."));
+		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "상태 변경 실패"));
 		}
 	}

--- a/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
+++ b/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.animal.api.management.animal.model.request.AdoptionConsultStatusRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalInsertRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO;
 import com.animal.api.management.animal.model.response.AdoptionConsultDetailResponseDTO;
@@ -29,5 +30,7 @@ public interface ShelterAnimalsMapper {
 	public List<AdoptionConsultListResponseDTO> getAdoptionConsultList(Map map);
 
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx);
+
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
+++ b/care/src/main/java/com/animal/api/management/animal/mapper/ShelterAnimalsMapper.java
@@ -32,5 +32,7 @@ public interface ShelterAnimalsMapper {
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx);
 
 	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto);
+	
+	public Integer checkAdoptionConsultShelter(int idx);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/model/request/AdoptionConsultStatusRequestDTO.java
+++ b/care/src/main/java/com/animal/api/management/animal/model/request/AdoptionConsultStatusRequestDTO.java
@@ -1,0 +1,21 @@
+package com.animal.api.management.animal.model.request;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdoptionConsultStatusRequestDTO {
+	private Integer idx;	// 컨트롤러에서 세팅
+	@NotNull(message = "상담 상태는 필수입니다.")
+	@Min(value = 1, message = "상담 상태는 1 ~ 4 여야 합니다.")
+	@Max(value = 4, message = "상담 상태는 1 ~ 4 여야 합니다.")
+	private Integer statusIdx;
+
+}

--- a/care/src/main/java/com/animal/api/management/animal/model/request/AdoptionConsultStatusRequestDTO.java
+++ b/care/src/main/java/com/animal/api/management/animal/model/request/AdoptionConsultStatusRequestDTO.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AdoptionConsultStatusRequestDTO {
-	private Integer idx;	// 컨트롤러에서 세팅
+	private Integer idx;	// 서비스에서 세팅
 	@NotNull(message = "상담 상태는 필수입니다.")
 	@Min(value = 1, message = "상담 상태는 1 ~ 4 여야 합니다.")
 	@Max(value = 4, message = "상담 상태는 1 ~ 4 여야 합니다.")

--- a/care/src/main/java/com/animal/api/management/animal/model/request/AnimalUpdateRequestDTO.java
+++ b/care/src/main/java/com/animal/api/management/animal/model/request/AnimalUpdateRequestDTO.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class AnimalUpdateRequestDTO {
-	@NotNull(message = "동물 관리번호는 필수입니다.")
+	// 서비스에서 세팅
 	private Integer idx;
 
 	@NotNull(message = "입양 상태는 필수입니다.")

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
@@ -13,22 +13,23 @@ import com.animal.api.management.animal.model.response.AnimalAddShelterInfoRespo
 
 public interface ShelterAnimalsService {
 
-	public static int NOT_ANIMAL = 0;
 	public static int POST_SUCCESS = 1;
 	public static int UPDATE_SUCCESS = 2;
 	public static int DELETE_SUCCESS = 3;
 	public static int UPLOAD_SUCCESS = 4;
-	public static int NOT_CONSULT = 5;
-	public static int NOT_OWNED_CONSULT= 6;
+	public static int NOT_ANIMAL = 5;
+	public static int NOT_OWNED_ANIMAL = 6;
+	public static int NOT_CONSULT = 7;
+	public static int NOT_OWNED_CONSULT = 8;
 	public static int ERROR = -1;
 
 	public AnimalAddShelterInfoResponseDTO getShelterProfile(int idx);
 
-	public int insertAnimal(AnimalInsertRequestDTO dto);
+	public int insertAnimal(AnimalInsertRequestDTO dto, int userIdx);
 
-	public int updateAnimal(AnimalUpdateRequestDTO dto);
+	public int updateAnimal(AnimalUpdateRequestDTO dto, int animalIdx, int userIdx);
 
-	public int deleteAnimal(int idx);
+	public int deleteAnimal(int animalIdx, int userIdx);
 
 	public int getAnimalShelter(int idx);
 
@@ -38,6 +39,6 @@ public interface ShelterAnimalsService {
 
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx);
 
-	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx,int consultIdx);
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx, int consultIdx);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
@@ -18,6 +18,7 @@ public interface ShelterAnimalsService {
 	public static int UPDATE_SUCCESS = 2;
 	public static int DELETE_SUCCESS = 3;
 	public static int UPLOAD_SUCCESS = 4;
+	public static int NOT_CONSULT = 5;
 	public static int ERROR = -1;
 
 	public AnimalAddShelterInfoResponseDTO getShelterProfile(int idx);
@@ -33,9 +34,9 @@ public interface ShelterAnimalsService {
 	public int uploadAnimalImage(MultipartFile[] files, int idx);
 
 	public List<AdoptionConsultListResponseDTO> getAdoptionConsultList(int idx, int listSize, int cp);
-	
+
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx);
-	
-	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto);
+
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
@@ -19,6 +19,7 @@ public interface ShelterAnimalsService {
 	public static int DELETE_SUCCESS = 3;
 	public static int UPLOAD_SUCCESS = 4;
 	public static int NOT_CONSULT = 5;
+	public static int NOT_OWNED_CONSULT= 6;
 	public static int ERROR = -1;
 
 	public AnimalAddShelterInfoResponseDTO getShelterProfile(int idx);
@@ -37,6 +38,6 @@ public interface ShelterAnimalsService {
 
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx);
 
-	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx);
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx,int consultIdx);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.animal.api.management.animal.model.request.AdoptionConsultStatusRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalInsertRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO;
 import com.animal.api.management.animal.model.response.AdoptionConsultDetailResponseDTO;
@@ -34,5 +35,7 @@ public interface ShelterAnimalsService {
 	public List<AdoptionConsultListResponseDTO> getAdoptionConsultList(int idx, int listSize, int cp);
 	
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx);
+	
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto);
 
 }

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.animal.api.common.util.FileManager;
 import com.animal.api.management.animal.mapper.ShelterAnimalsMapper;
+import com.animal.api.management.animal.model.request.AdoptionConsultStatusRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalInsertRequestDTO;
 import com.animal.api.management.animal.model.request.AnimalUpdateRequestDTO;
 import com.animal.api.management.animal.model.response.AdoptionConsultDetailResponseDTO;
@@ -103,6 +104,14 @@ public class ShelterAnimalsServiceImple implements ShelterAnimalsService {
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx) {
 		AdoptionConsultDetailResponseDTO dto = mapper.getAdoptionConsultDetail(idx);
 		return dto;
+	}
+	
+	@Override
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto) {
+		int result = mapper.updateAdoptionConsultStatus(dto);
+		
+		result = result > 0 ? UPDATE_SUCCESS : ERROR;
+		return result;
 	}
 
 	// 넘어온 페이지를 쿼리에 넣을 수 있게 가공하는 메서드

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
@@ -107,12 +107,15 @@ public class ShelterAnimalsServiceImple implements ShelterAnimalsService {
 	}
 
 	@Override
-	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx) {
-		Integer checkUserIdx = mapper.checkAdoptionConsultShelter(userIdx);
-		if (checkUserIdx == null) {	// 해당 보호시설의 상담 신청이 맞는지 검증
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx, int consultIdx) {
+		Integer checkUserIdx = mapper.checkAdoptionConsultShelter(consultIdx);
+		if (checkUserIdx == null) {// 해당 상담신청이 있는지 검증
 			return NOT_CONSULT;
 		}
-
+		if (checkUserIdx != userIdx) { // 해당 보호시설의 상담 신청이 맞는지 검증
+			return NOT_OWNED_CONSULT;
+		}
+		dto.setIdx(consultIdx);
 		int result = mapper.updateAdoptionConsultStatus(dto);
 		result = result > 0 ? UPDATE_SUCCESS : ERROR;
 		return result;

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
@@ -99,17 +99,21 @@ public class ShelterAnimalsServiceImple implements ShelterAnimalsService {
 
 		return consultList;
 	}
-	
+
 	@Override
 	public AdoptionConsultDetailResponseDTO getAdoptionConsultDetail(int idx) {
 		AdoptionConsultDetailResponseDTO dto = mapper.getAdoptionConsultDetail(idx);
 		return dto;
 	}
-	
+
 	@Override
-	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto) {
+	public int updateAdoptionConsultStatus(AdoptionConsultStatusRequestDTO dto, int userIdx) {
+		Integer checkUserIdx = mapper.checkAdoptionConsultShelter(userIdx);
+		if (checkUserIdx == null) {	// 해당 보호시설의 상담 신청이 맞는지 검증
+			return NOT_CONSULT;
+		}
+
 		int result = mapper.updateAdoptionConsultStatus(dto);
-		
 		result = result > 0 ? UPDATE_SUCCESS : ERROR;
 		return result;
 	}

--- a/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/animal/service/ShelterAnimalsServiceImple.java
@@ -34,7 +34,8 @@ public class ShelterAnimalsServiceImple implements ShelterAnimalsService {
 	}
 
 	@Override
-	public int insertAnimal(AnimalInsertRequestDTO dto) {
+	public int insertAnimal(AnimalInsertRequestDTO dto, int userIdx) {
+		dto.setUserIdx(userIdx);
 		int result = mapper.insertAnimal(dto);
 
 		result = result > 0 ? POST_SUCCESS : ERROR;
@@ -42,23 +43,37 @@ public class ShelterAnimalsServiceImple implements ShelterAnimalsService {
 	}
 
 	@Override
-	public int updateAnimal(AnimalUpdateRequestDTO dto) {
-		int result = mapper.updateAnimal(dto);
+	public int updateAnimal(AnimalUpdateRequestDTO dto, int animalIdx, int userIdx) {
+		Integer checkUserIdx = mapper.getAnimalShelter(animalIdx);
+		if (checkUserIdx == null) {// 해당 상담신청이 있는지 검증
+			return NOT_ANIMAL;
+		}
+		if (checkUserIdx != userIdx) { // 해당 보호시설의 유기동물이 맞는지 검증
+			return NOT_OWNED_ANIMAL;
+		}
+		dto.setIdx(animalIdx);
 
+		int result = mapper.updateAnimal(dto);
 		result = result > 0 ? UPDATE_SUCCESS : ERROR;
 		return result;
 	}
 
 	@Override
-	public int deleteAnimal(int idx) {
-		int result = mapper.deleteAnimal(idx);
+	public int deleteAnimal(int animalIdx, int userIdx) {
+		Integer checkUserIdx = mapper.getAnimalShelter(animalIdx);
+		if (checkUserIdx == null) {// 해당 상담신청이 있는지 검증
+			return NOT_ANIMAL;
+		}
+		if (checkUserIdx != userIdx) { // 해당 보호시설의 유기동물이 맞는지 검증
+			return NOT_OWNED_ANIMAL;
+		}
 
+		int result = mapper.deleteAnimal(animalIdx);
 		result = result > 0 ? DELETE_SUCCESS : ERROR;
 
 		if (result == DELETE_SUCCESS) {
-			fileManager.deleteFolder("animals", idx);
+			fileManager.deleteFolder("animals", animalIdx);
 		}
-
 		return result;
 	}
 

--- a/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
+++ b/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
@@ -136,7 +136,7 @@ ON
 WHERE
 	AC.IDX = #{idx}
 </select>
-<update id="updateAdoptionConsultStatus" parameterType=com.animal.api.management.animal.model.request.AdoptionConsultStatusRequestDTO>
+<update id="updateAdoptionConsultStatus" parameterType="com.animal.api.management.animal.model.request.AdoptionConsultStatusRequestDTO">
 UPDATE
 	ADOPTION_CONSULTS
 SET

--- a/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
+++ b/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
@@ -136,4 +136,12 @@ ON
 WHERE
 	AC.IDX = #{idx}
 </select>
+<update id="updateAdoptionConsultStatus" parameterType=com.animal.api.management.animal.model.request.AdoptionConsultStatusRequestDTO>
+UPDATE
+	ADOPTION_CONSULTS
+SET
+	ADOPTION_CONSULT_STATUS_IDX = #{statusIdx}
+WHERE
+	IDX = #{idx}
+</update>
 </mapper>

--- a/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
+++ b/care/src/main/resources/sql-mapper/animal/ShelterAnimalsMapper.xml
@@ -144,4 +144,15 @@ SET
 WHERE
 	IDX = #{idx}
 </update>
+<select id="checkAdoptionConsultShelter" parameterType="int" resultType="Integer">
+SELECT
+	A.USER_IDX
+FROM
+	ADOPTION_CONSULTS AC
+JOIN ANIMALS A
+ON
+	AC.ANIMAL_IDX = A.IDX
+where
+	AC.IDX = #{idx}
+</select>
 </mapper>


### PR DESCRIPTION
보호시설 관리 페이지에서 입양 상담 신청의 상태를 변경하는 기능 구현
- 로그인 여부 검증
- 보호시설 권한 검증
- 상담신청 유무 검증
- 상담 신청이 로그인한 보호소의 신청인지 검증
- 기존의 업데이트 기능과 딜리트 기능을 이번에 만든 스타일대로 리팩토링(기능변화는 없음)

로그인 검증 실패(401)
![image](https://github.com/user-attachments/assets/9e494ba3-265d-4247-9123-0281a5a53cbb)

권한 검증 실패(403)
![image](https://github.com/user-attachments/assets/ab9c0432-1440-4e88-9466-af0e5febb456)

상담신청 조회 실패(404)
![image](https://github.com/user-attachments/assets/8393be4c-b181-463c-9397-b839592112d6)

로그인한 보호소의 상담신청이 아닐 때(403)
![image](https://github.com/user-attachments/assets/19eef067-86db-4ed8-87b5-bc4cee53ac89)

상태 변경 성공(200)
![image](https://github.com/user-attachments/assets/56c90444-3e00-4408-8244-80e4be93e1cb)
