### PR TITLE
[PR]Feature/delete admin notice

### DIFF
--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -3,7 +3,6 @@ package com.animal.api.admin.board.controller;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
-import org.apache.ibatis.annotations.Delete;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -68,6 +67,13 @@ public class AdminBoardController {
 		}
 	}
 
+	/**
+	 * 관리자 페이지에서 공지사항을 삭제하는 메서드
+	 * 
+	 * @param idx     게시글 번호
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 성공 또는 실패 메세지
+	 */
 	@DeleteMapping("/{idx}")
 	public ResponseEntity<?> deleteNotice(@PathVariable int idx, HttpSession session) {
 		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");

--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -3,9 +3,11 @@ package com.animal.api.admin.board.controller;
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
+import org.apache.ibatis.annotations.Delete;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,11 +59,37 @@ public class AdminBoardController {
 
 		if (result == service.UPDATE_SUCCESS) {
 			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "공지사항 수정 성공", null));
+		} else if (result == service.NOTICE_NOT_FOUND) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "해당 글을 찾을 수 없습니다."));
 		} else if (result == service.NOT_NOTICE) {
-			return ResponseEntity.status(HttpStatus.NOT_FOUND)
-					.body(new ErrorResponseDTO(404, "해당 공지사항이 없거나 해당 글은 공지사항이 아닙니다."));
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "해당 글은 공지사항이 아닙니다."));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 수정 실패"));
+		}
+	}
+
+	@DeleteMapping("/{idx}")
+	public ResponseEntity<?> deleteNotice(@PathVariable int idx, HttpSession session) {
+		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
+
+		if (loginAdmin == null) { // 로그인 여부 검증
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		if (loginAdmin.getUserTypeIdx() != 3) { // 관리자 회원 검증
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
+		}
+
+		int result = service.deleteNotice(idx);
+
+		if (result == service.DELETE_SUCCESS) {
+			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "공지사항 삭제 성공", null));
+		} else if (result == service.NOTICE_NOT_FOUND) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "해당 글을 찾을 수 없습니다."));
+		} else if (result == service.NOT_NOTICE) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "해당 글은 공지사항이 아닙니다."));
+		} else {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 삭제 실패"));
 		}
 
 	}

--- a/care/src/main/java/com/animal/api/admin/board/mapper/AdminBoardMapper.java
+++ b/care/src/main/java/com/animal/api/admin/board/mapper/AdminBoardMapper.java
@@ -11,4 +11,6 @@ public interface AdminBoardMapper {
 
 	public int updateNotice(NoticeUpdateRequestDTO dto);
 
+	public int deleteNotice(int idx);
+
 }

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
@@ -11,4 +11,6 @@ public interface AdminBoardService {
 	public static int ERROR = -1;
 
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx);
+
+	public int deleteNotice(int idx);
 }

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
@@ -8,6 +8,7 @@ public interface AdminBoardService {
 	public static int DELETE_SUCCESS = 3;
 	public static int UPLOAD_SUCCESS = 4;
 	public static int NOT_NOTICE = 5;
+	public static int NOTICE_NOT_FOUND = 6;
 	public static int ERROR = -1;
 
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx);

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
@@ -28,4 +28,18 @@ public class AdminBoardServiceImple implements AdminBoardService {
 		result = result > 0 ? UPDATE_SUCCESS : ERROR;
 		return result;
 	}
+
+	@Override
+	public int deleteNotice(int idx) {
+		int boardTypeIdx = mapper.checkBoardType(idx);
+
+		if (boardTypeIdx != 1) { // 공지사항인지 확인
+			return NOT_NOTICE;
+		}
+
+		int result = mapper.deleteNotice(idx);
+
+		result = result > 0 ? UPDATE_SUCCESS : ERROR;
+		return result;
+	}
 }

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
@@ -16,7 +16,11 @@ public class AdminBoardServiceImple implements AdminBoardService {
 
 	@Override
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx) {
-		int boardTypeIdx = mapper.checkBoardType(idx);
+		Integer boardTypeIdx = mapper.checkBoardType(idx);
+		
+		if(boardTypeIdx==null) {
+			return NOTICE_NOT_FOUND;
+		}
 
 		if (boardTypeIdx != 1) { // 공지사항인지 확인
 			return NOT_NOTICE;
@@ -31,15 +35,19 @@ public class AdminBoardServiceImple implements AdminBoardService {
 
 	@Override
 	public int deleteNotice(int idx) {
-		int boardTypeIdx = mapper.checkBoardType(idx);
+		Integer boardTypeIdx = mapper.checkBoardType(idx);
 
+		if (boardTypeIdx == null) {
+			return NOTICE_NOT_FOUND;
+		}
+		
 		if (boardTypeIdx != 1) { // 공지사항인지 확인
 			return NOT_NOTICE;
 		}
 
 		int result = mapper.deleteNotice(idx);
 
-		result = result > 0 ? UPDATE_SUCCESS : ERROR;
+		result = result > 0 ? DELETE_SUCCESS : ERROR;
 		return result;
 	}
 }

--- a/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
@@ -20,4 +20,11 @@ SET
 	CONTENT = #{content}
 WHERE IDX = #{idx}
 </update>
+<delete id="deleteNotice" parameterType="int">
+DELETE
+FROM
+	BOARDS
+WHERE
+	IDX = #{idx}
+</delete>
 </mapper>


### PR DESCRIPTION
사이트 관리자 페이지에서 공지사항을 삭제하는 기능 구현

- 로그인 검증
- 권한 검증
- 공지사항 유무 검증
- 이전 수정과 이번 삭제 기능 예외처리 세분화
엔드포인트 : /api/admin/boards/{idx}

로그인 검증 실패(401)
![image](https://github.com/user-attachments/assets/fc6cb0ea-dcd2-4337-abe9-7aae711062ce)

해당 글을 찾을 수 없음(404)
![image](https://github.com/user-attachments/assets/455855ef-ee7c-4c99-85ec-4c3b2065a5dc)

해당 글은 공지사항이 아님(400)
![image](https://github.com/user-attachments/assets/40691af2-c0bf-4abc-b2e5-48d2514acffe)

삭제 성공(200)
![image](https://github.com/user-attachments/assets/3c29c9bd-b12d-47ff-8a42-0923e36b6243)
