### PR TITLE
[PR]Feature/get shelter board list

### DIFF
--- a/care/src/main/java/com/animal/api/management/animal/model/response/ShelterBoardResponseDTO.java
+++ b/care/src/main/java/com/animal/api/management/animal/model/response/ShelterBoardResponseDTO.java
@@ -1,0 +1,8 @@
+package com.animal.api.management.animal.model.response;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public class ShelterBoardResponseDTO {
+
+}

--- a/care/src/main/java/com/animal/api/management/animal/model/response/ShelterBoardResponseDTO.java
+++ b/care/src/main/java/com/animal/api/management/animal/model/response/ShelterBoardResponseDTO.java
@@ -1,8 +1,0 @@
-package com.animal.api.management.animal.model.response;
-
-import org.apache.ibatis.annotations.Mapper;
-
-@Mapper
-public class ShelterBoardResponseDTO {
-
-}

--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -349,7 +349,15 @@ public class ShelterManageController {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "답글 삭제 실패"));
 		}
 	}
-
+	
+	/**
+	 * 해당 보호시설 게시판 글 목록 조회 메서드 
+	 * 
+	 * @param cp 페이지번호
+	 * @param session 로그인 검증 세션 
+	 * 
+	 * @return 해당 보호시설 게시판 목록
+	 */
 	@GetMapping("/board")
 	public ResponseEntity<?> getShelterboardList(@RequestParam(value = "cp", defaultValue = "0") int cp,
 			HttpSession session) {
@@ -376,7 +384,15 @@ public class ShelterManageController {
 					.body(new OkResponseDTO<List<ShelterBoardResponseDTO>>(200, "보호소 게시판 목록 조회 성공", boardLists));
 		}
 	}
-
+	
+	/**
+	 * 해당 보호시설 게시판 상세정보 조회 메서드 
+	 * 
+	 * @param idx 게시판 번호 
+	 * @param session 로그인 검증 세션
+	 * 
+	 * @return 해당 보호시설 게시판 상세 정보 
+	 */
 	@GetMapping("/{idx}")
 	public ResponseEntity<?> getShelterBoardDetail(@PathVariable int idx, HttpSession session) {
 

--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -375,7 +375,23 @@ public class ShelterManageController {
 			return ResponseEntity.status(HttpStatus.OK)
 					.body(new OkResponseDTO<List<ShelterBoardResponseDTO>>(200, "보호소 게시판 목록 조회 성공", boardLists));
 		}
+	}
 
+	@GetMapping("/{idx}")
+	public ResponseEntity<?> getShelterBoardDetail(@PathVariable int idx, HttpSession session) {
+
+		LoginResponseDTO loginUser = shelterUserCheck(session);
+
+		int userIdx = loginUser.getIdx();
+
+		int result = shelterService.addBoardViewCount(idx);
+		ShelterBoardResponseDTO dto = shelterService.getShelterBoardDetail(idx, userIdx);
+
+		if (dto == null) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "삭제되거나 없는 게시물"));
+		} else {
+			return ResponseEntity.ok(new OkResponseDTO<ShelterBoardResponseDTO>(200, "게시물 상세정보 조회 성공", dto));
+		}
 	}
 
 	/**

--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -358,7 +358,7 @@ public class ShelterManageController {
 	 * 
 	 * @return 해당 보호시설 게시판 목록
 	 */
-	@GetMapping("/board")
+	@GetMapping("/boards")
 	public ResponseEntity<?> getShelterboardList(@RequestParam(value = "cp", defaultValue = "0") int cp,
 			HttpSession session) {
 
@@ -393,7 +393,7 @@ public class ShelterManageController {
 	 * 
 	 * @return 해당 보호시설 게시판 상세 정보 
 	 */
-	@GetMapping("/{idx}")
+	@GetMapping("boards/{idx}")
 	public ResponseEntity<?> getShelterBoardDetail(@PathVariable int idx, HttpSession session) {
 
 		LoginResponseDTO loginUser = shelterUserCheck(session);

--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -365,7 +365,7 @@ public class ShelterManageController {
 			cp = (cp - 1) * listSize;
 		}
 
-		List<ShelterBoardResponseDTO> boardLists = shelterService.getShelterboardList(userIdx, listSize, cp);
+		List<ShelterBoardResponseDTO> boardLists = shelterService.getShelterBoardList(userIdx, listSize, cp);
 
 		if (boardLists == null) {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 접근"));

--- a/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
+++ b/care/src/main/java/com/animal/api/management/shelter/controller/ShelterManageController.java
@@ -28,7 +28,9 @@ import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestD
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
+import com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO;
 import com.animal.api.management.shelter.service.ShelterManageService;
+import com.animal.api.support.model.response.UserNoticeResponseDTO;
 
 /**
  * 보호시설 관리자 페이지의 보호시설관리 관련 컨트롤러 클래스
@@ -319,12 +321,12 @@ public class ShelterManageController {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "답글 수정 실패"));
 		}
 	}
-	
+
 	/**
-	 * 해당 보호시설 입양 리뷰글에 대한 답글 삭제 메서드 
+	 * 해당 보호시설 입양 리뷰글에 대한 답글 삭제 메서드
 	 * 
-	 * @param reviewIdx 입양 리뷰 글 번호 
-	 * @param session 로그인 검증 세션
+	 * @param reviewIdx 입양 리뷰 글 번호
+	 * @param session   로그인 검증 세션
 	 * 
 	 * @return 해당 보호시설 입양 리뷰글 답글 삭제
 	 */
@@ -346,6 +348,34 @@ public class ShelterManageController {
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "답글 삭제 실패"));
 		}
+	}
+
+	@GetMapping("/board")
+	public ResponseEntity<?> getShelterboardList(@RequestParam(value = "cp", defaultValue = "0") int cp,
+			HttpSession session) {
+
+		LoginResponseDTO loginUser = shelterUserCheck(session);
+
+		int userIdx = loginUser.getIdx();
+
+		int listSize = 5;
+		if (cp == 0) {
+			cp = 1;
+		} else {
+			cp = (cp - 1) * listSize;
+		}
+
+		List<ShelterBoardResponseDTO> boardLists = shelterService.getShelterboardList(userIdx, listSize, cp);
+
+		if (boardLists == null) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 접근"));
+		} else if (boardLists.size() == 0) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "데이터 없음"));
+		} else {
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new OkResponseDTO<List<ShelterBoardResponseDTO>>(200, "보호소 게시판 목록 조회 성공", boardLists));
+		}
+
 	}
 
 	/**

--- a/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
+++ b/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
@@ -16,16 +16,18 @@ import com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO;
 
 @Mapper
 public interface ManagementShelterMapper {
-
+	
+	//보호시설 기본정보
 	public AllManageShelterResponseDTO getShelterInfo(int userIdx);
 
 	public int updateSheterInfo(ShelterInfoUpdateRequestDTO dto);
-
+	
+	//보호시설 리뷰
 	public List<ManageVolunteerReviewResponseDTO> getVolunteerReview(Map map);
 
 	public List<ManageAdoptionReviewResponseDTO> getAdoptionReview(Map map);
 
-	public int updateTurnVR(ManageVolunteerReplyRequestDTO dto);
+	public int updateTurnVR(ManageVolunteerReplyRequestDTO dto); //VolunteerReview 순번
 
 	public int addVolunteerReviewApply(ManageVolunteerReplyRequestDTO dto);
 
@@ -37,7 +39,7 @@ public interface ManagementShelterMapper {
 
 	public Integer checkShelterUserVR(ManageVolunteerReplyRequestDTO dto);
 
-	public int updateTurnAR(Map map);
+	public int updateTurnAR(Map map); //AdoptionReview 순번
 
 	public Integer checkAdoptionReview(@Param("reviewIdx") int reviewIdx);
 
@@ -49,8 +51,11 @@ public interface ManagementShelterMapper {
 	
 	public int deleteAdoptionReviewApply(ManageAdoptionReplyRequestDTO dto);
 	
+	//보호시설 게시판
 	public List<ShelterBoardResponseDTO> getShelterBoardList(Map map);
 	
-	public ShelterBoardResponseDTO getShelterBoardDetail(int idx, int userIdx);
+	public ShelterBoardResponseDTO getShelterBoardDetail(@Param("idx")int idx, @Param("userIdx")int userIdx);
+	
+	public int updateBoardViews(int idx);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
+++ b/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
@@ -12,6 +12,7 @@ import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestD
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
+import com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO;
 
 @Mapper
 public interface ManagementShelterMapper {
@@ -47,5 +48,7 @@ public interface ManagementShelterMapper {
 	public int updateAdoptionReviewApply(ManageAdoptionReplyRequestDTO dto);
 	
 	public int deleteAdoptionReviewApply(ManageAdoptionReplyRequestDTO dto);
+	
+	public List<ShelterBoardResponseDTO> getShelterboardList(Map map);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
+++ b/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
@@ -49,6 +49,6 @@ public interface ManagementShelterMapper {
 	
 	public int deleteAdoptionReviewApply(ManageAdoptionReplyRequestDTO dto);
 	
-	public List<ShelterBoardResponseDTO> getShelterboardList(Map map);
+	public List<ShelterBoardResponseDTO> getShelterBoardList(Map map);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
+++ b/care/src/main/java/com/animal/api/management/shelter/mapper/ManagementShelterMapper.java
@@ -50,5 +50,7 @@ public interface ManagementShelterMapper {
 	public int deleteAdoptionReviewApply(ManageAdoptionReplyRequestDTO dto);
 	
 	public List<ShelterBoardResponseDTO> getShelterBoardList(Map map);
+	
+	public ShelterBoardResponseDTO getShelterBoardDetail(int idx, int userIdx);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/model/response/ShelterBoardResponseDTO.java
+++ b/care/src/main/java/com/animal/api/management/shelter/model/response/ShelterBoardResponseDTO.java
@@ -1,0 +1,28 @@
+package com.animal.api.management.shelter.model.response;
+
+import java.sql.Timestamp;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ShelterBoardResponseDTO {
+	
+	private int idx;
+	private int userIdx;
+	private int boardTypeIdx;
+	private String title;
+	private String content;
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+	private Timestamp createdAt;
+	private int views;
+	private int ref;
+	private int lev;
+	private int turn;
+	
+}

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
@@ -1,6 +1,7 @@
 package com.animal.api.management.shelter.service;
 
 import java.util.List;
+import java.util.Map;
 
 import com.animal.api.management.shelter.model.request.ManageAdoptionReplyRequestDTO;
 import com.animal.api.management.shelter.model.request.ManageVolunteerReplyRequestDTO;
@@ -8,14 +9,15 @@ import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestD
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
+import com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO;
 
 public interface ShelterManageService {
 
+	public static int NOT_SHELTER_MANAGER = -3;
+	public static int REPLY_ERROR = -2;
+	public static int NOT_REVIEW = -1;
 	public static int UPDATE_OK = 0;
 	public static int DELETE_OK = 1;
-	public static int NOT_REVIEW = -1;
-	public static int REPLY_ERROR = -2;
-	public static int NOT_SHELTER_MANAGER = -3;
 	
 	public AllManageShelterResponseDTO getShelterInfo(int idx);
 
@@ -36,5 +38,7 @@ public interface ShelterManageService {
 	public int updateAdoptionReviewApply(ManageAdoptionReplyRequestDTO dto, int userIdx, int reviewIdx);
 	
 	public int deleteAdoptionReviewApply(int userIdx, int reviewIdx);
+	
+	public List<ShelterBoardResponseDTO> getShelterboardList(int listSize, int cp);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
@@ -1,7 +1,6 @@
 package com.animal.api.management.shelter.service;
 
 import java.util.List;
-import java.util.Map;
 
 import com.animal.api.management.shelter.model.request.ManageAdoptionReplyRequestDTO;
 import com.animal.api.management.shelter.model.request.ManageVolunteerReplyRequestDTO;
@@ -39,6 +38,8 @@ public interface ShelterManageService {
 	
 	public int deleteAdoptionReviewApply(int userIdx, int reviewIdx);
 	
-	public List<ShelterBoardResponseDTO> getShelterboardList(int userIdx, int listSize, int cp);
+	public List<ShelterBoardResponseDTO> getShelterBoardList(int userIdx, int listSize, int cp);
+	
+	public ShelterBoardResponseDTO getShelterBoardDetail(int idx, int userIdx);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
@@ -39,6 +39,6 @@ public interface ShelterManageService {
 	
 	public int deleteAdoptionReviewApply(int userIdx, int reviewIdx);
 	
-	public List<ShelterBoardResponseDTO> getShelterboardList(int listSize, int cp);
+	public List<ShelterBoardResponseDTO> getShelterboardList(int userIdx, int listSize, int cp);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageService.java
@@ -41,5 +41,7 @@ public interface ShelterManageService {
 	public List<ShelterBoardResponseDTO> getShelterBoardList(int userIdx, int listSize, int cp);
 	
 	public ShelterBoardResponseDTO getShelterBoardDetail(int idx, int userIdx);
+	
+	public int addBoardViewCount(int idx);
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
@@ -257,5 +257,11 @@ public class ShelterManageServiceImple implements ShelterManageService {
 		}
 		return dto;
 	}
+	
+	@Override
+	public int addBoardViewCount(int idx) {
+		int count = mapper.updateBoardViews(idx);
+		return count;
+	}
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
@@ -235,10 +235,11 @@ public class ShelterManageServiceImple implements ShelterManageService {
 	}
 	
 	@Override
-	public List<ShelterBoardResponseDTO> getShelterboardList(int listSize, int cp) {
+	public List<ShelterBoardResponseDTO> getShelterboardList(int userIdx, int listSize, int cp) {
 		
 		Map<String, Integer> map = new HashMap<String, Integer>();
 		
+		map.put("userIdx", userIdx);
 		map.put("listSize", listSize);
 		map.put("cp", cp);
 		

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
@@ -138,10 +138,10 @@ public class ShelterManageServiceImple implements ShelterManageService {
 		dto.setUserIdx(userIdx);
 
 		Integer shelterCheck = mapper.checkShelterUserVR(dto);
-		if (shelterCheck == null || shelterCheck == 0) {// 해당 보호소 관리자인지 확인 
+		if (shelterCheck == null || shelterCheck == 0) {// 해당 보호소 관리자인지 확인
 			return NOT_SHELTER_MANAGER;
 		}
-		
+
 		int count = mapper.deleteVolunteerReviewApply(dto);
 		if (count > 0) {
 			return DELETE_OK;
@@ -183,10 +183,10 @@ public class ShelterManageServiceImple implements ShelterManageService {
 			return REPLY_ERROR;
 		}
 	}
-	
+
 	@Override
 	public int updateAdoptionReviewApply(ManageAdoptionReplyRequestDTO dto, int userIdx, int reviewIdx) {
-		
+
 		Integer reviewCheck = mapper.checkAdoptionReview(reviewIdx);
 
 		if (reviewCheck == null) { // 리뷰글이 있는지 확인
@@ -208,10 +208,10 @@ public class ShelterManageServiceImple implements ShelterManageService {
 			return REPLY_ERROR;
 		}
 	}
-	
+
 	@Override
 	public int deleteAdoptionReviewApply(int userIdx, int reviewIdx) {
-		
+
 		Integer reviewCheck = mapper.checkAdoptionReview(reviewIdx);
 		if (reviewCheck == null) {// 리뷰글이 있는지 확인
 			return NOT_REVIEW;
@@ -220,12 +220,12 @@ public class ShelterManageServiceImple implements ShelterManageService {
 		ManageAdoptionReplyRequestDTO dto = new ManageAdoptionReplyRequestDTO();
 		dto.setReviewIdx(reviewIdx);
 		dto.setUserIdx(userIdx);
-		
+
 		Integer shelterCheck = mapper.checkShelterUserAR(dto);
-		if (shelterCheck == null || shelterCheck == 0) {// 해당 보호소 관리자인지 확인 
+		if (shelterCheck == null || shelterCheck == 0) {// 해당 보호소 관리자인지 확인
 			return NOT_SHELTER_MANAGER;
 		}
-		
+
 		int count = mapper.deleteAdoptionReviewApply(dto);
 		if (count > 0) {
 			return DELETE_OK;
@@ -233,20 +233,29 @@ public class ShelterManageServiceImple implements ShelterManageService {
 			return REPLY_ERROR;
 		}
 	}
-	
+
 	@Override
-	public List<ShelterBoardResponseDTO> getShelterboardList(int userIdx, int listSize, int cp) {
-		
+	public List<ShelterBoardResponseDTO> getShelterBoardList(int userIdx, int listSize, int cp) {
+
 		Map<String, Integer> map = new HashMap<String, Integer>();
-		
+
 		map.put("userIdx", userIdx);
 		map.put("listSize", listSize);
 		map.put("cp", cp);
-		
-		List<ShelterBoardResponseDTO> boardLists = mapper.getShelterboardList(map);
-		
+
+		List<ShelterBoardResponseDTO> boardLists = mapper.getShelterBoardList(map);
+
 		return boardLists;
 	}
 
+	@Override
+	public ShelterBoardResponseDTO getShelterBoardDetail(int idx, int userIdx) {
+
+		ShelterBoardResponseDTO dto = mapper.getShelterBoardDetail(idx, userIdx);
+		if (dto != null && dto.getContent() != null) {
+			dto.setContent(dto.getContent().replaceAll("\n", "<br>"));
+		}
+		return dto;
+	}
 
 }

--- a/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
+++ b/care/src/main/java/com/animal/api/management/shelter/service/ShelterManageServiceImple.java
@@ -16,6 +16,7 @@ import com.animal.api.management.shelter.model.request.ShelterInfoUpdateRequestD
 import com.animal.api.management.shelter.model.response.AllManageShelterResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageAdoptionReviewResponseDTO;
 import com.animal.api.management.shelter.model.response.ManageVolunteerReviewResponseDTO;
+import com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO;
 
 @Service
 @Primary
@@ -231,7 +232,19 @@ public class ShelterManageServiceImple implements ShelterManageService {
 		} else {
 			return REPLY_ERROR;
 		}
+	}
+	
+	@Override
+	public List<ShelterBoardResponseDTO> getShelterboardList(int listSize, int cp) {
 		
+		Map<String, Integer> map = new HashMap<String, Integer>();
+		
+		map.put("listSize", listSize);
+		map.put("cp", cp);
+		
+		List<ShelterBoardResponseDTO> boardLists = mapper.getShelterboardList(map);
+		
+		return boardLists;
 	}
 
 

--- a/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
@@ -257,7 +257,7 @@ AND
 	USER_IDX = #{userIdx}
 </delete>
 
-<select id="getShelterboardList" resultType="com.">
+<select id="getShelterboardList" resultType="com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO">
 SELECT 
 	IDX,
 	USER_IDX,

--- a/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
@@ -256,5 +256,31 @@ WHERE
 AND 
 	USER_IDX = #{userIdx}
 </delete>
+
+<select id="getShelterboardList" resultType="com.">
+SELECT 
+	IDX,
+	USER_IDX,
+	BOARD_TYPE_IDX,
+	TITLE,
+	CONTENT,
+	CREATED_AT,
+	VIEWS,
+	REF,
+	LEV,
+	TURN
+FROM
+	BOARDS
+WHERE
+	BOARD_TYPE_IDX = 3
+and 
+	USER_IDX = #{userIdx}
+ORDER BY
+	IDX DESC
+LIMIT
+#{listSize} OFFSET #{cp}
+
+</select>
+
  
  </mapper>

--- a/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
@@ -257,7 +257,7 @@ AND
 	USER_IDX = #{userIdx}
 </delete>
 
-<select id="getShelterboardList" resultType="com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO">
+<select id="getShelterBoardList" resultType="com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO">
 SELECT 
 	IDX,
 	USER_IDX,
@@ -273,13 +273,34 @@ FROM
 	BOARDS
 WHERE
 	BOARD_TYPE_IDX = 3
-and 
+AND
 	USER_IDX = #{userIdx}
 ORDER BY
 	IDX DESC
 LIMIT
 #{listSize} OFFSET #{cp}
+</select>
 
+<select id="getShelter">
+SELECT 
+	IDX,
+	USER_IDX,
+	BOARD_TYPE_IDX,
+	TITLE,
+	CONTENT,
+	CREATED_AT,
+	VIEWS,
+	REF,
+	LEV,
+	TURN
+FROM
+	BOARDS
+WHERE
+	BOARD_TYPE_IDX = 3
+AND
+	USER_IDX = #{userIdx}
+AND 
+	IDX = #{idx}
 </select>
 
  

--- a/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
@@ -281,7 +281,7 @@ LIMIT
 #{listSize} OFFSET #{cp}
 </select>
 
-<select id="getShelter">
+<select id="getShelterBoardDetail" parameterType="int" resultType="com.animal.api.management.shelter.model.response.ShelterBoardResponseDTO">
 SELECT 
 	IDX,
 	USER_IDX,

--- a/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/ManagementShelterMapper.xml
@@ -303,5 +303,14 @@ AND
 	IDX = #{idx}
 </select>
 
+<update id="updateBoardViews" parameterType="int">
+UPDATE
+	BOARDS
+SET
+	VIEWS = VIEWS + 1
+WHERE
+	IDX = #{idx}
+</update>
+
  
  </mapper>

--- a/care/src/main/resources/sql-mapper/support/UserSupportMapper.xml
+++ b/care/src/main/resources/sql-mapper/support/UserSupportMapper.xml
@@ -43,7 +43,7 @@ FROM
 	BOARDS
 WHERE
 	BOARD_TYPE_IDX = 1
-	AND IDX = ${idx}
+	AND IDX = #{idx}
 </select>
 
 <select id="searchAllNotice" parameterType="map" resultType="com.animal.api.support.model.response.UserNoticeResponseDTO">
@@ -83,7 +83,7 @@ UPDATE
 SET
 	VIEWS = VIEWS + 1
 WHERE
-	IDX = ${idx}
+	IDX = #{idx}
 </update>
 
 


### PR DESCRIPTION
- 보호소 관리 페이지의 해당 보호소 내 게시판 목록, 상세정보 조회 기능 구현
(목록 조회 기능 구현하면서 상세정보 조회까지 같이 추가하여 구현하였습니다)
- 첨부파일 다운 등과 같은 기능 구현은 따로 이슈를 빼서 기능 구현 할 예정

  **- 목록 URL : /care/api/management/shelter/boards?cp=**
  **- 상세정보 URL : care/api/management/shelter/boards/{idx}**

**<미 로그인시>**
<img width="937" alt="image" src="https://github.com/user-attachments/assets/36442a9e-0058-4de0-8169-500686d45d5a" />

**<보호소 계정이 아닐 시>**
<img width="950" alt="image" src="https://github.com/user-attachments/assets/38d66ff9-5954-452e-86c7-6fed4d6743a0" />

**<목록 조회 성공 시>**
<img width="898" alt="image" src="https://github.com/user-attachments/assets/af41aadb-7e75-49bc-b72a-40eceb7ed816" />

**<상세정보 조회 성공 시>**
<img width="779" alt="image" src="https://github.com/user-attachments/assets/18dac13e-5a48-4644-92cb-4b39fe2a9b22" />

**<데이터가 없을 시>**
<img width="901" alt="image" src="https://github.com/user-attachments/assets/e055e546-9c51-4c83-b14e-15d872d6910e" />