### PR TITLE
[PR]Feature/add notice

### DIFF
--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -25,8 +25,9 @@ import com.animal.api.common.model.OkResponseDTO;
  * 사이트 관리자 페이지의 게시글 관련 기능 클래스
  * 
  * @author Rege-97
- * @since 2025-06-24
- * @see com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
+ * @since 2025-06-25
+ * @see com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO
+ * @see com.animal.api.admin.board.model.request.NoticeInsertRequestDTO
  */
 @RestController
 @RequestMapping("/api/admin/boards")
@@ -101,6 +102,12 @@ public class AdminBoardController {
 		}
 	}
 
+	/**
+	 * 관리자 페이지에서 공지사항을 등록하는 메서드
+	 * @param dto 공지사항 입력 폼 데이터
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 성공 또는 실패 메세지
+	 */
 	@PostMapping("/notices")
 	public ResponseEntity<?> insertNotice(@Valid @RequestBody NoticeInsertRequestDTO dto, HttpSession session) {
 		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
@@ -121,4 +128,5 @@ public class AdminBoardController {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 등록 실패"));
 		}
 	}
+	
 }

--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -137,6 +137,13 @@ public class AdminBoardController {
 		}
 	}
 
+	/**
+	 * 공지사항 등록 또는 수정 시 첨부파일 업로드 메서드
+	 * 
+	 * @param idx   게시글 번호
+	 * @param files 첨부파일
+	 * @return 성공 또는 실패 메세지
+	 */
 	@PostMapping("/notices/upload/{idx}")
 	public ResponseEntity<?> uploadNoticeFiles(@PathVariable int idx, MultipartFile[] files) {
 		int result = service.uploadNoticeFiles(files, idx);

--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -8,11 +8,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
 import com.animal.api.admin.board.service.AdminBoardService;
 import com.animal.api.auth.model.response.LoginResponseDTO;
@@ -41,7 +43,7 @@ public class AdminBoardController {
 	 * @param session 로그인 검증을 위한 세션
 	 * @return 성공 또는 실패 메세지
 	 */
-	@PutMapping("/{idx}")
+	@PutMapping("/notices/{idx}")
 	public ResponseEntity<?> updateNotice(@PathVariable int idx, @Valid @RequestBody NoticeUpdateRequestDTO dto,
 			HttpSession session) {
 		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
@@ -74,7 +76,7 @@ public class AdminBoardController {
 	 * @param session 로그인 검증을 위한 세션
 	 * @return 성공 또는 실패 메세지
 	 */
-	@DeleteMapping("/{idx}")
+	@DeleteMapping("/notices/{idx}")
 	public ResponseEntity<?> deleteNotice(@PathVariable int idx, HttpSession session) {
 		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
 
@@ -97,6 +99,26 @@ public class AdminBoardController {
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 삭제 실패"));
 		}
+	}
 
+	@PostMapping("/notices")
+	public ResponseEntity<?> insertNotice(@Valid @RequestBody NoticeInsertRequestDTO dto, HttpSession session) {
+		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
+
+		if (loginAdmin == null) { // 로그인 여부 검증
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		if (loginAdmin.getUserTypeIdx() != 3) { // 관리자 회원 검증
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
+		}
+
+		int result = service.insertNotice(dto, loginAdmin.getIdx());
+
+		if (result == service.POST_SUCCESS) {
+			return ResponseEntity.status(HttpStatus.CREATED).body(new OkResponseDTO<Void>(201, "공지사항 등록 성공", null));
+		} else {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 등록 실패"));
+		}
 	}
 }

--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -1,5 +1,8 @@
 package com.animal.api.admin.board.controller;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
@@ -104,7 +108,8 @@ public class AdminBoardController {
 
 	/**
 	 * 관리자 페이지에서 공지사항을 등록하는 메서드
-	 * @param dto 공지사항 입력 폼 데이터
+	 * 
+	 * @param dto     공지사항 입력 폼 데이터
 	 * @param session 로그인 검증을 위한 세션
 	 * @return 성공 또는 실패 메세지
 	 */
@@ -123,10 +128,23 @@ public class AdminBoardController {
 		int result = service.insertNotice(dto, loginAdmin.getIdx());
 
 		if (result == service.POST_SUCCESS) {
-			return ResponseEntity.status(HttpStatus.CREATED).body(new OkResponseDTO<Void>(201, "공지사항 등록 성공", null));
+			Map<String, Integer> map = new HashMap<String, Integer>();
+			map.put("createdIdx", dto.getIdx());
+			return ResponseEntity.status(HttpStatus.CREATED)
+					.body(new OkResponseDTO<Map<String, Integer>>(201, "공지사항 등록 성공", map));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 등록 실패"));
 		}
 	}
-	
+
+	@PostMapping("/notices/upload/{idx}")
+	public ResponseEntity<?> uploadNoticeFiles(@PathVariable int idx, MultipartFile[] files) {
+		int result = service.uploadNoticeFiles(files, idx);
+		if (result == service.UPLOAD_SUCCESS) {
+			return ResponseEntity.status(HttpStatus.CREATED).body(new OkResponseDTO<Void>(201, "첨부파일 업로드 성공", null));
+		} else {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "첨부파일ㄹ 업로드 실패"));
+		}
+	}
+
 }

--- a/care/src/main/java/com/animal/api/admin/board/mapper/AdminBoardMapper.java
+++ b/care/src/main/java/com/animal/api/admin/board/mapper/AdminBoardMapper.java
@@ -2,6 +2,7 @@ package com.animal.api.admin.board.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
 
 @Mapper
@@ -12,5 +13,7 @@ public interface AdminBoardMapper {
 	public int updateNotice(NoticeUpdateRequestDTO dto);
 
 	public int deleteNotice(int idx);
+
+	public int insertNotice(NoticeInsertRequestDTO dto);
 
 }

--- a/care/src/main/java/com/animal/api/admin/board/model/request/NoticeInsertRequestDTO.java
+++ b/care/src/main/java/com/animal/api/admin/board/model/request/NoticeInsertRequestDTO.java
@@ -24,5 +24,8 @@ public class NoticeInsertRequestDTO {
 	@NotBlank(message = "게시글 본문을 적어주세요.")
 	@Size(max = 2000, message = "본문을 2000자 이내로 정해주세요.")
 	private String content;
+	
+	// 등록 후 나오는 idx 번호
+	int idx;
 
 }

--- a/care/src/main/java/com/animal/api/admin/board/model/request/NoticeInsertRequestDTO.java
+++ b/care/src/main/java/com/animal/api/admin/board/model/request/NoticeInsertRequestDTO.java
@@ -1,0 +1,21 @@
+package com.animal.api.admin.board.model.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class NoticeInsertRequestDTO {
+	// 서비스에서 세팅
+	private Integer userIdx;
+
+	@NotNull(message = "게시글 제목은 필수입니다.")
+	@NotBlank(message = "게시글 제목을 적어주세요.")
+	@Size(max = 100, message = "제목을 100자 이내로 정해주세요.")
+	private String title;
+
+	@NotNull(message = "게시글 본문은 필수입니다.")
+	@NotBlank(message = "게시글 본문을 적어주세요.")
+	@Size(max = 2000, message = "본문을 2000자 이내로 정해주세요.")
+	private String content;
+
+}

--- a/care/src/main/java/com/animal/api/admin/board/model/request/NoticeInsertRequestDTO.java
+++ b/care/src/main/java/com/animal/api/admin/board/model/request/NoticeInsertRequestDTO.java
@@ -4,6 +4,13 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class NoticeInsertRequestDTO {
 	// 서비스에서 세팅
 	private Integer userIdx;

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
@@ -1,5 +1,7 @@
 package com.animal.api.admin.board.service;
 
+import org.springframework.web.multipart.MultipartFile;
+
 import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
 
@@ -17,4 +19,6 @@ public interface AdminBoardService {
 	public int deleteNotice(int idx);
 
 	public int insertNotice(NoticeInsertRequestDTO dto, int userIdx);
+
+	public int uploadNoticeFiles(MultipartFile[] files, int idx);
 }

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
@@ -1,5 +1,6 @@
 package com.animal.api.admin.board.service;
 
+import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
 
 public interface AdminBoardService {
@@ -14,4 +15,6 @@ public interface AdminBoardService {
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx);
 
 	public int deleteNotice(int idx);
+
+	public int insertNotice(NoticeInsertRequestDTO dto, int userIdx);
 }

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import com.animal.api.admin.board.mapper.AdminBoardMapper;
+import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
 
 @Service
@@ -17,8 +18,8 @@ public class AdminBoardServiceImple implements AdminBoardService {
 	@Override
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx) {
 		Integer boardTypeIdx = mapper.checkBoardType(idx);
-		
-		if(boardTypeIdx==null) {
+
+		if (boardTypeIdx == null) {
 			return NOTICE_NOT_FOUND;
 		}
 
@@ -40,7 +41,7 @@ public class AdminBoardServiceImple implements AdminBoardService {
 		if (boardTypeIdx == null) {
 			return NOTICE_NOT_FOUND;
 		}
-		
+
 		if (boardTypeIdx != 1) { // 공지사항인지 확인
 			return NOT_NOTICE;
 		}
@@ -48,6 +49,15 @@ public class AdminBoardServiceImple implements AdminBoardService {
 		int result = mapper.deleteNotice(idx);
 
 		result = result > 0 ? DELETE_SUCCESS : ERROR;
+		return result;
+	}
+
+	@Override
+	public int insertNotice(NoticeInsertRequestDTO dto, int userIdx) {
+		dto.setUserIdx(userIdx);
+		int result = mapper.insertNotice(dto);
+
+		result = result > 0 ? POST_SUCCESS : ERROR;
 		return result;
 	}
 }

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
@@ -3,10 +3,12 @@ package com.animal.api.admin.board.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.animal.api.admin.board.mapper.AdminBoardMapper;
 import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
+import com.animal.api.common.util.FileManager;
 
 @Service
 @Primary
@@ -14,6 +16,8 @@ public class AdminBoardServiceImple implements AdminBoardService {
 
 	@Autowired
 	private AdminBoardMapper mapper;
+	@Autowired
+	private FileManager fileManager;
 
 	@Override
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx) {
@@ -59,5 +63,17 @@ public class AdminBoardServiceImple implements AdminBoardService {
 
 		result = result > 0 ? POST_SUCCESS : ERROR;
 		return result;
+	}
+
+	@Override
+	public int uploadNoticeFiles(MultipartFile[] files, int idx) {
+		boolean result = fileManager.uploadFiles("boards", idx, files);
+
+		if (result) {
+			return UPLOAD_SUCCESS;
+		} else {
+			mapper.deleteNotice(idx);
+			return ERROR;
+		}
 	}
 }

--- a/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
@@ -27,4 +27,33 @@ FROM
 WHERE
 	IDX = #{idx}
 </delete>
+<insert id="insertNotice" parameterType="com.animal.api.admin.board.model.request.NoticeInsertRequestDTO">
+INSERT
+	INTO
+	BOARDS (
+  USER_IDX,
+	BOARD_TYPE_IDX,
+	TITLE,
+	CONTENT,
+	VIEWS,
+	REF,
+	LEV,
+	TURN
+)
+SELECT
+	#{userIdx},
+	3,
+	#{title},
+	#{content},
+	0,
+	IFNULL(MAX_REF + 1, 1),
+	0,
+	0
+FROM
+	(
+	SELECT
+		MAX(REF) AS MAX_REF
+	FROM
+		BOARDS) AS sub
+</insert>
 </mapper>

--- a/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
@@ -27,7 +27,7 @@ FROM
 WHERE
 	IDX = #{idx}
 </delete>
-<insert id="insertNotice" parameterType="com.animal.api.admin.board.model.request.NoticeInsertRequestDTO">
+<insert id="insertNotice" parameterType="com.animal.api.admin.board.model.request.NoticeInsertRequestDTO" useGeneratedKeys="true" keyProperty="idx">
 INSERT
 	INTO
 	BOARDS (


### PR DESCRIPTION
사이트 관리 페이지에서 공지사항 등록 기능 구현
- 로그인 검증
- 권한 검증
- 등록 성공 유무 검증
- 공지사항관련 엔드포인트 수정
- 파일 업로드 구현
- 동시성 문제 해결을 위해 ref 최대값을 찾고 인서트 하는 것이 아닌 insert into select를 사용하여 조회와 동시에 삽입되도록 구현

엔드포인트 : /api/admin/boards/notices

로그인 검증 실패(401)
![image](https://github.com/user-attachments/assets/1bf17718-a234-446e-af46-be4b9b944970)

게시글 등록 성공(201)
![image](https://github.com/user-attachments/assets/2cc41d56-aff9-4950-90ec-023e68cd86c0)

파일 업로드 성공(201)
![image](https://github.com/user-attachments/assets/e3545287-de39-4b49-92d1-a8552ad3c6db)
