### PR TITLE
[PR]Feature/get board list

### DIFF
--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -56,6 +56,15 @@ public class AdminBoardController {
 	@Autowired
 	private UserSupportService userSupportService;
 
+	/**
+	 * 사이트 관리 페이지의 게시판 리스트 조회
+	 * 
+	 * @param cp      현재 페이지
+	 * @param type    검색조건
+	 * @param keyword 검색어
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 조회된 게시글 리스트
+	 */
 	@GetMapping
 	public ResponseEntity<?> getBoardList(@RequestParam(value = "cp", defaultValue = "0") int cp,
 			@RequestParam(value = "type", required = false) String type,
@@ -87,6 +96,13 @@ public class AdminBoardController {
 		}
 	}
 
+	/**
+	 * 사이트 관리 페이지의 게시글 상세정보
+	 * 
+	 * @param idx     게시글 번호
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 해당 게시글의 상세정보
+	 */
 	@GetMapping("/{idx}")
 	public ResponseEntity<?> getBoardDetail(@PathVariable int idx, HttpSession session) {
 		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
@@ -109,6 +125,15 @@ public class AdminBoardController {
 		}
 	}
 
+	/**
+	 * 사이트 관리 페이지의 공지사항 조회
+	 * 
+	 * @param cp      현재 페이지
+	 * @param title   글 제목
+	 * @param content 본문 내용
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 조회된 공지사항 리스트
+	 */
 	@GetMapping("/notices")
 	public ResponseEntity<?> getNoticeList(@RequestParam(value = "cp", defaultValue = "0") int cp,
 			@RequestParam(value = "title", required = false) String title,
@@ -143,6 +168,13 @@ public class AdminBoardController {
 		}
 	}
 
+	/**
+	 * 사이트 관리 페이지에서의 공지사항 상세정보
+	 * 
+	 * @param idx     게시글 번호
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 조회된 공지사항 상세정보
+	 */
 	@GetMapping("/notices/{idx}")
 	public ResponseEntity<?> getNoticeDetail(@PathVariable int idx, HttpSession session) {
 		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");

--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -1,6 +1,7 @@
 package com.animal.api.admin.board.controller;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpSession;
@@ -10,11 +11,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,8 +25,13 @@ import com.animal.api.admin.board.model.request.NoticeInsertRequestDTO;
 import com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO;
 import com.animal.api.admin.board.service.AdminBoardService;
 import com.animal.api.auth.model.response.LoginResponseDTO;
+import com.animal.api.board.model.response.AllBoardListResponseDTO;
+import com.animal.api.board.model.response.BoardDetailResponseDTO;
+import com.animal.api.board.service.UserBoardService;
 import com.animal.api.common.model.ErrorResponseDTO;
 import com.animal.api.common.model.OkResponseDTO;
+import com.animal.api.support.model.response.UserNoticeResponseDTO;
+import com.animal.api.support.service.UserSupportService;
 
 /**
  * 사이트 관리자 페이지의 게시글 관련 기능 클래스
@@ -38,7 +46,94 @@ import com.animal.api.common.model.OkResponseDTO;
 public class AdminBoardController {
 
 	@Autowired
-	private AdminBoardService service;
+	private AdminBoardService adminBoardService;
+	@Autowired
+	private UserBoardService userBoardService;
+	@Autowired
+	private UserSupportService userSupportService;
+
+	@GetMapping
+	public ResponseEntity<?> getBoardList(@RequestParam(value = "cp", defaultValue = "0") int cp,
+			@RequestParam(value = "type", required = false) String type,
+			@RequestParam(value = "keyword", required = false) String keyword, HttpSession session) {
+		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
+
+		if (loginAdmin == null) { // 로그인 여부 검증
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		if (loginAdmin.getUserTypeIdx() != 3) { // 관리자 회원 검증
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
+		}
+		int listSize = 3;
+		List<AllBoardListResponseDTO> boardList = null;
+		if (type != null || keyword != null) {
+			boardList = userBoardService.searchBoards(type, keyword, listSize, cp);
+		} else {
+			boardList = userBoardService.getAllBoards(listSize, cp);
+
+		}
+		if (boardList == null) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 요청"));
+		} else if (boardList.size() == 0) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "데이터가 존재하지않음"));
+		} else {
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new OkResponseDTO<List<AllBoardListResponseDTO>>(200, "게시판 조회 성공", boardList));
+		}
+	}
+
+	@GetMapping("/{idx}")
+	public ResponseEntity<?> getBoardDetail(@PathVariable int idx, HttpSession session) {
+		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
+
+		if (loginAdmin == null) { // 로그인 여부 검증
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		if (loginAdmin.getUserTypeIdx() != 3) { // 관리자 회원 검증
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
+		}
+
+		BoardDetailResponseDTO boardDetail = userBoardService.getBoardDetail(idx);
+
+		if (boardDetail == null) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "게시판 상세 데이터가 존재하지않음"));
+		} else {
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new OkResponseDTO<BoardDetailResponseDTO>(200, "게시판 상세 조회 성공", boardDetail));
+		}
+	}
+
+	@GetMapping("/notices")
+	public ResponseEntity<?> getAllNotice(@RequestParam(value = "cp", defaultValue = "0") int cp,
+			@RequestParam(value = "title", required = false) String title,
+			@RequestParam(value = "content", required = false) String content) {
+
+		int listSize = 5;
+		if (cp == 0) {
+			cp = 1;
+		} else {
+			cp = (cp - 1) * listSize;
+		}
+
+		List<UserNoticeResponseDTO> noticeAllList = null;
+
+		if (title != null || content != null) {
+			noticeAllList = userSupportService.searchAllNotice(listSize, cp, title, content);
+		} else {
+			noticeAllList = userSupportService.getAllNotice(listSize, cp);
+		}
+
+		if (noticeAllList == null) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 접근"));
+		} else if (noticeAllList.size() == 0) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "데이터 없음"));
+		} else {
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new OkResponseDTO<List<UserNoticeResponseDTO>>(200, "조회 성공", noticeAllList));
+		}
+	}
 
 	/**
 	 * 관리자 페이지에서 공지사항을 수정하는 메서드
@@ -61,13 +156,13 @@ public class AdminBoardController {
 			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
 		}
 
-		int result = service.updateNotice(dto, idx);
+		int result = adminBoardService.updateNotice(dto, idx);
 
-		if (result == service.UPDATE_SUCCESS) {
+		if (result == adminBoardService.UPDATE_SUCCESS) {
 			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "공지사항 수정 성공", null));
-		} else if (result == service.NOTICE_NOT_FOUND) {
+		} else if (result == adminBoardService.NOTICE_NOT_FOUND) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "해당 글을 찾을 수 없습니다."));
-		} else if (result == service.NOT_NOTICE) {
+		} else if (result == adminBoardService.NOT_NOTICE) {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "해당 글은 공지사항이 아닙니다."));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 수정 실패"));
@@ -93,13 +188,13 @@ public class AdminBoardController {
 			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
 		}
 
-		int result = service.deleteNotice(idx);
+		int result = adminBoardService.deleteNotice(idx);
 
-		if (result == service.DELETE_SUCCESS) {
+		if (result == adminBoardService.DELETE_SUCCESS) {
 			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "공지사항 삭제 성공", null));
-		} else if (result == service.NOTICE_NOT_FOUND) {
+		} else if (result == adminBoardService.NOTICE_NOT_FOUND) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "해당 글을 찾을 수 없습니다."));
-		} else if (result == service.NOT_NOTICE) {
+		} else if (result == adminBoardService.NOT_NOTICE) {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "해당 글은 공지사항이 아닙니다."));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "공지사항 삭제 실패"));
@@ -125,9 +220,9 @@ public class AdminBoardController {
 			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
 		}
 
-		int result = service.insertNotice(dto, loginAdmin.getIdx());
+		int result = adminBoardService.insertNotice(dto, loginAdmin.getIdx());
 
-		if (result == service.POST_SUCCESS) {
+		if (result == adminBoardService.POST_SUCCESS) {
 			Map<String, Integer> map = new HashMap<String, Integer>();
 			map.put("createdIdx", dto.getIdx());
 			return ResponseEntity.status(HttpStatus.CREATED)
@@ -146,8 +241,8 @@ public class AdminBoardController {
 	 */
 	@PostMapping("/notices/upload/{idx}")
 	public ResponseEntity<?> uploadNoticeFiles(@PathVariable int idx, MultipartFile[] files) {
-		int result = service.uploadNoticeFiles(files, idx);
-		if (result == service.UPLOAD_SUCCESS) {
+		int result = adminBoardService.uploadNoticeFiles(files, idx);
+		if (result == adminBoardService.UPLOAD_SUCCESS) {
 			return ResponseEntity.status(HttpStatus.CREATED).body(new OkResponseDTO<Void>(201, "첨부파일 업로드 성공", null));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "첨부파일ㄹ 업로드 실패"));

--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -40,6 +40,10 @@ import com.animal.api.support.service.UserSupportService;
  * @since 2025-06-25
  * @see com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO
  * @see com.animal.api.admin.board.model.request.NoticeInsertRequestDTO
+ * @see com.animal.api.board.model.response.AllBoardListResponseDTO
+ * @see com.animal.api.board.model.response.BoardDetailResponseDTO
+ * @see com.animal.api.support.model.response.UserNoticeResponseDTO
+ * @see com.animal.api.board.model.response.BoardDetailResponseDTO
  */
 @RestController
 @RequestMapping("/api/admin/boards")

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
@@ -53,6 +53,9 @@ public class AdminBoardServiceImple implements AdminBoardService {
 		int result = mapper.deleteNotice(idx);
 
 		result = result > 0 ? DELETE_SUCCESS : ERROR;
+		if (result == DELETE_SUCCESS) {	// 게시글 삭제 시 파일도 같이 삭제
+			fileManager.deleteFolder("boards", idx);
+		}
 		return result;
 	}
 

--- a/care/src/main/java/com/animal/api/animal/model/response/AnimalDetailResponseDTO.java
+++ b/care/src/main/java/com/animal/api/animal/model/response/AnimalDetailResponseDTO.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class AnimalDetailResponseDTO {
 	private int idx;
+	private int userIdx;
 	private String name;
 	private char gender;
 	private int age;

--- a/care/src/main/java/com/animal/api/management/animal/model/request/AnimalInsertRequestDTO.java
+++ b/care/src/main/java/com/animal/api/management/animal/model/request/AnimalInsertRequestDTO.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class AnimalInsertRequestDTO {
-	@NotNull(message = "유저 IDX는 필수입니다.")
+	// 서비스에서 세팅
 	private Integer userIdx;
 
 	@NotNull(message = "입양 상태 IDX는 필수입니다.")

--- a/care/src/main/java/com/animal/api/support/service/UserSupportServiceImple.java
+++ b/care/src/main/java/com/animal/api/support/service/UserSupportServiceImple.java
@@ -19,6 +19,12 @@ public class UserSupportServiceImple implements UserSupportService {
 
 	@Override
 	public List<UserNoticeResponseDTO> getAllNotice(int listSize, int cp) {
+		if (cp == 0) {
+			cp = 1;
+		} else {
+			cp = (cp - 1) * listSize;
+		}
+		
 		Map<String, Integer> map = new HashMap<String, Integer>();
 
 		map.put("listSize", listSize);

--- a/care/src/main/resources/sql-mapper/animal/UserAnimalMapper.xml
+++ b/care/src/main/resources/sql-mapper/animal/UserAnimalMapper.xml
@@ -102,6 +102,7 @@ LIMIT #{listSize} OFFSET #{cp}
 <select id="getAnimalDetail" parameterType="int" resultType="com.animal.api.animal.model.response.AnimalDetailResponseDTO">
 SELECT
 	A.IDX,
+	S.USER_IDX,
 	A.NAME,
 	A.GENDER,
 	A.AGE,


### PR DESCRIPTION
보호시설 관리 페이지의 게시판 목록 및 검색 구현
- 기존에 만들어진 컨트롤러와 서비스에 권한 검증만 추가로 넣어서 구현
- 하다보니 권한 검증 없이 이건 이미 있으니까 안만들어도 되겠지~ 했던 기능들도 비슷하게 추가 구현
- 기능 자체는 로그인 권한 검증 말고는 동일함

추가된 기능
- 관리자 공지사항 목록
- 관리자 공지사항 상세
- 관리자 게시판 목록
- 관리자 게시판 상세
- 보호시설 유기동물 목록
- 보호시설 유기동물 상세