### PR TITLE
[PR]Feature/get shelter list

### DIFF
--- a/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
@@ -1,0 +1,10 @@
+package com.animal.api.admin.shelter.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/shelters")
+public class AdminShelterController {
+
+}

--- a/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
@@ -18,6 +18,13 @@ import com.animal.api.common.model.OkResponseDTO;
 import com.animal.api.shelter.model.response.AllShelterListResponseDTO;
 import com.animal.api.shelter.service.UserShelterService;
 
+/**
+ * 사이트 관리자 페이지 내의 보호시설 관리 페이지 컨트롤러
+ * 
+ * @author Rege-97
+ * @since 2025-06-25
+ * @see com.animal.api.shelter.model.response.AllShelterListResponseDTO
+ */
 @RestController
 @RequestMapping("/api/admin/shelters")
 public class AdminShelterController {
@@ -32,7 +39,7 @@ public class AdminShelterController {
 	 * @param shelterName    검색된 보호소 이름
 	 * @param shelterAddress 선택된 보호소 주소
 	 * @param shelterType    선택된 보호소 타입
-	 * @param session 로그인 검증을 위한 세션
+	 * @param session        로그인 검증을 위한 세션
 	 * 
 	 * @return 조회된 보호소의 리스트
 	 */

--- a/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
@@ -1,10 +1,72 @@
 package com.animal.api.admin.shelter.controller;
 
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.animal.api.auth.model.response.LoginResponseDTO;
+import com.animal.api.common.model.ErrorResponseDTO;
+import com.animal.api.common.model.OkResponseDTO;
+import com.animal.api.shelter.model.response.AllShelterListResponseDTO;
+import com.animal.api.shelter.service.UserShelterService;
 
 @RestController
 @RequestMapping("/api/admin/shelters")
 public class AdminShelterController {
 
+	@Autowired
+	private UserShelterService userShelterService;
+
+	/**
+	 * 사이트 관리자 페이지의 보호시설 조회 및 검색 메서드
+	 * 
+	 * @param cp             현재 페이지
+	 * @param shelterName    검색된 보호소 이름
+	 * @param shelterAddress 선택된 보호소 주소
+	 * @param shelterType    선택된 보호소 타입
+	 * @param session 로그인 검증을 위한 세션
+	 * 
+	 * @return 조회된 보호소의 리스트
+	 */
+	@GetMapping
+	public ResponseEntity<?> getShelters(@RequestParam(value = "cp", defaultValue = "0") int cp,
+			@RequestParam(value = "shelterName", required = false) String shelterName,
+			@RequestParam(value = "shelterAddress", required = false) String shelterAddress,
+			@RequestParam(value = "shelterType", required = false) String shelterType, HttpSession session) {
+		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
+
+		if (loginAdmin == null) { // 로그인 여부 검증
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		if (loginAdmin.getUserTypeIdx() != 3) { // 관리자 회원 검증
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
+		}
+
+		int listSize = 3;
+		List<AllShelterListResponseDTO> shelterList = null;
+
+		if (shelterName != null || shelterAddress != null || shelterType != null) {
+			shelterList = userShelterService.searchShelters(listSize, cp, shelterName, shelterAddress, shelterType);
+		} else {
+			shelterList = userShelterService.getAllShelters(listSize, cp);
+		}
+
+		if (shelterList == null) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "잘못된 접근입니다."));
+		} else if (shelterList.size() == 0) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "조회된 데이터가 없습니다."));
+		} else {
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new OkResponseDTO<List<AllShelterListResponseDTO>>(200, "조회 성공", shelterList));
+		}
+	}
 }

--- a/care/src/main/java/com/animal/api/admin/shelter/mapper/AdminShelterMapper.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/mapper/AdminShelterMapper.java
@@ -1,0 +1,8 @@
+package com.animal.api.admin.shelter.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AdminShelterMapper {
+
+}

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
@@ -1,0 +1,5 @@
+package com.animal.api.admin.shelter.service;
+
+public interface AdminShelterService {
+
+}

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
@@ -1,0 +1,10 @@
+package com.animal.api.admin.shelter.service;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Service
+@Primary
+public class AdminShelterServiceImple implements AdminShelterService {
+	
+}


### PR DESCRIPTION
사이트 관리자 페이지에서 보호시설 목록 조회 및 검색 기능 구현
- 기존의 보호시설 목록 서비스 및 매퍼 활용
- 관리자 검증 추가
- DTO와 쿼리에 보호소담당자 정보 추가

엔드포인트 : /api/admin/shelters

로그인 검증 실패 (401)
![image](https://github.com/user-attachments/assets/4b25594c-9e40-45df-ab66-580ed375e09b)

조회된 데이터 없음(404)
![image](https://github.com/user-attachments/assets/f1fb65ac-57b5-4550-9eb7-9318e84b75fc)

조회 성공(200)
![image](https://github.com/user-attachments/assets/3fc20458-9774-4379-b3f9-f78f036fc2a3)
