### PR TITLE
[PR]Feature/delete shelter animal

### DIFF
--- a/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
@@ -20,6 +20,7 @@ import com.animal.api.animal.service.UserAnimalService;
 import com.animal.api.auth.model.response.LoginResponseDTO;
 import com.animal.api.common.model.ErrorResponseDTO;
 import com.animal.api.common.model.OkResponseDTO;
+import com.animal.api.management.animal.service.ShelterAnimalsService;
 import com.animal.api.shelter.model.response.AllShelterListResponseDTO;
 import com.animal.api.shelter.model.response.ShelterAnimalsResponseDTO;
 import com.animal.api.shelter.model.response.ShelterDetailResponseDTO;
@@ -37,11 +38,11 @@ import com.animal.api.shelter.service.UserShelterService;
 public class AdminShelterController {
 
 	@Autowired
-	private AdminShelterService adminShelterService;
-	@Autowired
 	private UserShelterService userShelterService;
 	@Autowired
 	private UserAnimalService userAnimalService;
+	@Autowired
+	private ShelterAnimalsService shelterAnimalService;
 
 	/**
 	 * 사이트 관리자 페이지의 보호시설 조회 및 검색 메서드
@@ -213,12 +214,14 @@ public class AdminShelterController {
 	/**
 	 * 사이트 관리자 페이지에서 유기동물의 데이터를 삭제하는 메서드
 	 * 
-	 * @param idx     유기동물 관리번호
-	 * @param session 로그인 검증을 위한 세션
+	 * @param shelterIdx 보호시설의 idx
+	 * @param animalIdx  유기동물 관리번호
+	 * @param session    로그인 검증을 위한 세션
 	 * @return 성공 또는 실패 메세지
 	 */
-	@DeleteMapping("/{idx}")
-	public ResponseEntity<?> deleteAnimal(@PathVariable int idx, HttpSession session) {
+	@DeleteMapping("/{shelterIdx}/animals/{animalIdx}")
+	public ResponseEntity<?> deleteAnimal(@PathVariable int shelterIdx, @PathVariable int animalIdx,
+			HttpSession session) {
 		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
 
 		if (loginAdmin == null) { // 로그인 여부 검증
@@ -229,13 +232,15 @@ public class AdminShelterController {
 			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
 		}
 
-		int result = adminShelterService.deleteAnimal(idx);
+		int result = shelterAnimalService.deleteAnimal(animalIdx, shelterIdx);
 
-		if (result == adminShelterService.DELETE_SUCCESS) {
+		if (result == shelterAnimalService.DELETE_SUCCESS) {
 			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "유기동물 삭제 성공", null));
-		} else if (result == adminShelterService.NOT_ANIMAL) {
+		} else if (result == shelterAnimalService.NOT_ANIMAL) {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND)
 					.body(new ErrorResponseDTO(404, "해당 유기동물이 존재하지 않거나 이미 삭제되었습니다."));
+		} else if (result == shelterAnimalService.NOT_OWNED_ANIMAL) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "해당 보호시설의 유기동물이 아닙니다."));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "유기동물 삭제 실패"));
 		}

--- a/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/controller/AdminShelterController.java
@@ -240,7 +240,7 @@ public class AdminShelterController {
 			return ResponseEntity.status(HttpStatus.NOT_FOUND)
 					.body(new ErrorResponseDTO(404, "해당 유기동물이 존재하지 않거나 이미 삭제되었습니다."));
 		} else if (result == shelterAnimalService.NOT_OWNED_ANIMAL) {
-			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "해당 보호시설의 유기동물이 아닙니다."));
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "해당 보호시설의 유기동물이 아닙니다."));
 		} else {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "유기동물 삭제 실패"));
 		}

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
@@ -1,5 +1,12 @@
 package com.animal.api.admin.shelter.service;
 
 public interface AdminShelterService {
-
+	public static int POST_SUCCESS = 1;
+	public static int UPDATE_SUCCESS = 2;
+	public static int DELETE_SUCCESS = 3;
+	public static int UPLOAD_SUCCESS = 4;
+	public static int NOT_ANIMAL = 5;
+	public static int ERROR = -1;
+	
+	public int deleteAnimal(int animalIdx, int userIdx);
 }

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
@@ -8,5 +8,5 @@ public interface AdminShelterService {
 	public static int NOT_ANIMAL = 5;
 	public static int ERROR = -1;
 	
-	public int deleteAnimal(int animalIdx, int userIdx);
+	public int deleteAnimal(int idx);
 }

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
@@ -1,12 +1,5 @@
 package com.animal.api.admin.shelter.service;
 
 public interface AdminShelterService {
-	public static int POST_SUCCESS = 1;
-	public static int UPDATE_SUCCESS = 2;
-	public static int DELETE_SUCCESS = 3;
-	public static int UPLOAD_SUCCESS = 4;
-	public static int NOT_ANIMAL = 5;
-	public static int ERROR = -1;
-	
-	public int deleteAnimal(int idx);
+
 }

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
@@ -1,10 +1,33 @@
 package com.animal.api.admin.shelter.service;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
+
+import com.animal.api.common.util.FileManager;
+import com.animal.api.management.animal.mapper.ShelterAnimalsMapper;
 
 @Service
 @Primary
 public class AdminShelterServiceImple implements AdminShelterService {
-	
+	@Autowired
+	private ShelterAnimalsMapper shelterAnimalsMapper;
+	@Autowired
+	private FileManager fileManager;
+
+	@Override
+	public int deleteAnimal(int animalIdx, int userIdx) {
+		Integer checkUserIdx = shelterAnimalsMapper.getAnimalShelter(animalIdx);
+		if (checkUserIdx == null) {// 해당 상담신청이 있는지 검증
+			return NOT_ANIMAL;
+		}
+
+		int result = shelterAnimalsMapper.deleteAnimal(animalIdx);
+		result = result > 0 ? DELETE_SUCCESS : ERROR;
+
+		if (result == DELETE_SUCCESS) {
+			fileManager.deleteFolder("animals", animalIdx);
+		}
+		return result;
+	}
 }

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
@@ -1,33 +1,10 @@
 package com.animal.api.admin.shelter.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
-
-import com.animal.api.common.util.FileManager;
-import com.animal.api.management.animal.mapper.ShelterAnimalsMapper;
 
 @Service
 @Primary
 public class AdminShelterServiceImple implements AdminShelterService {
-	@Autowired
-	private ShelterAnimalsMapper shelterAnimalsMapper;
-	@Autowired
-	private FileManager fileManager;
 
-	@Override
-	public int deleteAnimal(int idx) {
-		Integer checkUserIdx = shelterAnimalsMapper.getAnimalShelter(idx);
-		if (checkUserIdx == null) {// 해당 상담신청이 있는지 검증
-			return NOT_ANIMAL;
-		}
-
-		int result = shelterAnimalsMapper.deleteAnimal(idx);
-		result = result > 0 ? DELETE_SUCCESS : ERROR;
-
-		if (result == DELETE_SUCCESS) {
-			fileManager.deleteFolder("animals", idx);
-		}
-		return result;
-	}
 }

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
@@ -16,17 +16,17 @@ public class AdminShelterServiceImple implements AdminShelterService {
 	private FileManager fileManager;
 
 	@Override
-	public int deleteAnimal(int animalIdx, int userIdx) {
-		Integer checkUserIdx = shelterAnimalsMapper.getAnimalShelter(animalIdx);
+	public int deleteAnimal(int idx) {
+		Integer checkUserIdx = shelterAnimalsMapper.getAnimalShelter(idx);
 		if (checkUserIdx == null) {// 해당 상담신청이 있는지 검증
 			return NOT_ANIMAL;
 		}
 
-		int result = shelterAnimalsMapper.deleteAnimal(animalIdx);
+		int result = shelterAnimalsMapper.deleteAnimal(idx);
 		result = result > 0 ? DELETE_SUCCESS : ERROR;
 
 		if (result == DELETE_SUCCESS) {
-			fileManager.deleteFolder("animals", animalIdx);
+			fileManager.deleteFolder("animals", idx);
 		}
 		return result;
 	}


### PR DESCRIPTION
사이트 관리자 페이지에서 특정 보호소 페이지에서 유기동물을 삭제하는 기능
- 기존의 보호시설 관리자 페이지의 서비스 재활용하여 적용
- 로그인 검증
- 유기동물 유무 검증
- 보호시설 소속 유무 검증
엔드포인트 : /api/admin/shelters/{shelterIdx}/animals/{animalIdx}

로그인 검증 실패(401)
![image](https://github.com/user-attachments/assets/f5211ebd-438c-4a56-9a48-6fe386ea011b)

유기동물 없음(404)
![image](https://github.com/user-attachments/assets/1e1b8fb6-9bf4-45b5-ad67-6718dcf87c78)

해당 보호시설 유기동물이 아님(400)
![image](https://github.com/user-attachments/assets/f24c087c-5992-4abc-a469-e8ed9d573eff)

삭제 성공(200)
![image](https://github.com/user-attachments/assets/4a60c542-2fca-4900-afb7-81987b6b4ce2)
