### PR TITLE
Feature/post user board writing like

### DIFF
--- a/care/src/main/java/com/animal/api/board/mapper/UserBoardMapper.java
+++ b/care/src/main/java/com/animal/api/board/mapper/UserBoardMapper.java
@@ -31,5 +31,9 @@ public interface UserBoardMapper {
 
 	public int deleteBoard(int idx);
 
+	public Integer checkMyHeart(Map map);
+
 	public int addBoardHeart(Map map);
+
+	public int deleteBoardHeart(Map map);
 }

--- a/care/src/main/java/com/animal/api/board/mapper/UserBoardMapper.java
+++ b/care/src/main/java/com/animal/api/board/mapper/UserBoardMapper.java
@@ -30,4 +30,6 @@ public interface UserBoardMapper {
 	public Integer checkMyBoard(int idx);
 
 	public int deleteBoard(int idx);
+
+	public int addBoardHeart(Map map);
 }

--- a/care/src/main/java/com/animal/api/board/model/response/BoardDetailResponseDTO.java
+++ b/care/src/main/java/com/animal/api/board/model/response/BoardDetailResponseDTO.java
@@ -23,4 +23,6 @@ public class BoardDetailResponseDTO {
 	private int views;
 	private int likeCount;
 	private List<String> filePaths;
+	// 로그인후 상세페이지 조회시 좋아요 클릭 여부(true:클릭/false:클릭x)
+	private boolean heart;
 }

--- a/care/src/main/java/com/animal/api/board/service/UserBoardService.java
+++ b/care/src/main/java/com/animal/api/board/service/UserBoardService.java
@@ -40,4 +40,6 @@ public interface UserBoardService {
 	public int updateBoard(BoardUpdateRequestDTO dto, int idx);
 
 	public int deleteBoard(int idx, int userIdx);
+
+	public int addBoardHeart(int userIdx, int boardIdx);
 }

--- a/care/src/main/java/com/animal/api/board/service/UserBoardService.java
+++ b/care/src/main/java/com/animal/api/board/service/UserBoardService.java
@@ -25,6 +25,9 @@ public interface UserBoardService {
 	static int NOT_OWNED_BOARD = 13;
 	static int BOARD_NOT_FOUND = 14;
 	static int DELETE_SUCCESS = 15;
+	static int HEART_SUCCESS = 16;
+	static int HEART_NOT_FOUND = 17;
+	static int ALREADY_HEART = 18;
 	static int ERROR = -1;
 
 	public List<AllBoardListResponseDTO> getAllBoards(int listSize, int cp);
@@ -41,5 +44,9 @@ public interface UserBoardService {
 
 	public int deleteBoard(int idx, int userIdx);
 
+	public int checkMyHeart(int userIdx, int boardIdx);
+
 	public int addBoardHeart(int userIdx, int boardIdx);
+
+	public int deleteBoardHeart(int userIdx, int boardIdx);
 }

--- a/care/src/main/java/com/animal/api/board/service/UserBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/board/service/UserBoardServiceImple.java
@@ -139,12 +139,60 @@ public class UserBoardServiceImple implements UserBoardService {
 	}
 
 	@Override
-	public int addBoardHeart(int userIdx, int boardIdx) {
+	public int checkMyHeart(int userIdx, int boardIdx) {
 		Map<String, Integer> map = new HashMap<String, Integer>();
 		map.put("userIdx", userIdx);
 		map.put("boardIdx", boardIdx);
+
+		Integer result = mapper.checkMyHeart(map);
+
+		if (result == null || result == 0) {
+			return HEART_NOT_FOUND;
+		} else {
+			return ALREADY_HEART;
+		}
+	}
+
+	@Override
+	public int addBoardHeart(int userIdx, int boardIdx) {
+
+		if (userIdx < 1) {
+			return IDX_NOT_FOUND;
+		} else if (boardIdx < 1) {
+			return BOARD_NOT_FOUND;
+		}
+
+		Map<String, Integer> map = new HashMap<String, Integer>();
+		map.put("userIdx", userIdx);
+		map.put("boardIdx", boardIdx);
+
 		int result = mapper.addBoardHeart(map);
 
-		return result;
+		if (result > 0) {
+			return HEART_SUCCESS;
+		} else {
+			return ERROR;
+		}
+	}
+
+	@Override
+	public int deleteBoardHeart(int userIdx, int boardIdx) {
+		if (userIdx < 1) {
+			return IDX_NOT_FOUND;
+		} else if (boardIdx < 1) {
+			return BOARD_NOT_FOUND;
+		}
+
+		Map<String, Integer> map = new HashMap<String, Integer>();
+		map.put("userIdx", userIdx);
+		map.put("boardIdx", boardIdx);
+
+		int result = mapper.deleteBoardHeart(map);
+
+		if (result > 0) {
+			return DELETE_SUCCESS;
+		} else {
+			return ERROR;
+		}
 	}
 }

--- a/care/src/main/java/com/animal/api/board/service/UserBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/board/service/UserBoardServiceImple.java
@@ -137,4 +137,14 @@ public class UserBoardServiceImple implements UserBoardService {
 			return ERROR;
 		}
 	}
+
+	@Override
+	public int addBoardHeart(int userIdx, int boardIdx) {
+		Map<String, Integer> map = new HashMap<String, Integer>();
+		map.put("userIdx", userIdx);
+		map.put("boardIdx", boardIdx);
+		int result = mapper.addBoardHeart(map);
+
+		return result;
+	}
 }

--- a/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
@@ -158,10 +158,29 @@ WHERE
 	IDX = #{idx}
 </delete>
 
+<select id="checkMyHeart" parameterType="Map" resultType="Integer">
+SELECT 
+	COUNT(*)
+FROM
+	BOARD_LIKES
+WHERE 
+	USER_IDX = #{userIdx}
+	AND BOARD_IDX = #{boardIdx}
+</select>
+
 <insert id="addBoardHeart" parameterType="Map">
 INSERT
 	INTO
 	BOARD_LIKES(USER_IDX, BOARD_IDX, IS_LIKE)
 VALUES(#{userIdx}, #{boardIdx}, 1)
 </insert>
+
+<delete id="deleteBoardHeart" parameterType="Map">
+DELETE
+FROM
+	BOARD_LIKES
+WHERE
+	USER_IDX = #{userIdx}
+	AND BOARD_IDX =	#{boardIdx}
+</delete>
 </mapper>

--- a/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
@@ -157,4 +157,11 @@ FROM
 WHERE
 	IDX = #{idx}
 </delete>
+
+<insert id="addBoardLike" parameterType="Map">
+INSERT
+	INTO
+	BOARD_LIKES(USER_IDX, BOARD_IDX, IS_LIKE)
+VALUES(#{userIdx}, #{boardIdx}, 1)
+</insert>
 </mapper>

--- a/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/UserBoardMapper.xml
@@ -158,7 +158,7 @@ WHERE
 	IDX = #{idx}
 </delete>
 
-<insert id="addBoardLike" parameterType="Map">
+<insert id="addBoardHeart" parameterType="Map">
 INSERT
 	INTO
 	BOARD_LIKES(USER_IDX, BOARD_IDX, IS_LIKE)


### PR DESCRIPTION
자유게시판 글 좋아요,좋아요 취소 기능 구현

**-URL
/api/boards/{boardIdx}/auth(GET 로그인후 글 상세조회) 
/api/boards/{boardIdx}/hearts (POST 좋아요)
/api/boards/{boardIdx}/hearts(DELETE 좋아요 취소)**


구현 상세
1.자유게시판 글 상세페이지 컨트롤러(로그인 권한확인)
2.자유게시판 좋아요
3.자유게시판 좋아요 취소

이번 이슈하다가 알게된건데 controller에서 서비스 연속으로 호출하면 동시에 호출하면 꼬일수 있어서
서비스 호출후 리턴 , 서비스 호출 리턴이 맞는것 같아여(아래 사진처럼 하면 원하는 리턴이 안나왔어요)
![image](https://github.com/user-attachments/assets/8586c97a-e29a-4458-a75f-228dd0b1b4b6)

-------------------------------------------------------------------------------------------------------

로그인 검증
![1로그인 검증](https://github.com/user-attachments/assets/b4435833-1b5e-4f4f-8310-a8aaa63c7701)

로그인후 글 상세페이지 조회(200)
heart가 false(로그인한 회원이 좋아요 하고 있지 않은 상태)
![2로그인후 상세정보 조회(HEART FALSE)](https://github.com/user-attachments/assets/3743f4cc-fec7-4434-b51c-5234241ff82f)

좋아요 취소한 상태에서 취소시(404)
![3좋아요 취소글 취소시](https://github.com/user-attachments/assets/3fd9bde2-1227-4bf6-bd3b-a0e3999e285e)

좋아요 성공(201)
![4좋아요 성공](https://github.com/user-attachments/assets/8d01e853-9eb1-43b3-a80d-d48d45502502)

좋아요 성공후 글 상세페이지 조회
heart가 true(로그인한 회원이 좋아요 한 상태)
![5좋아요후 상세정보조회](https://github.com/user-attachments/assets/011de75d-ab2b-4121-8225-678854c19411)

좋아요 중복 방지(409)
![6좋아요 중복 방지](https://github.com/user-attachments/assets/2b5ee971-a047-43ad-94b1-65432615c547)

