### PR TITLE
[PR]Feature/delete board

### DIFF
--- a/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
+++ b/care/src/main/java/com/animal/api/admin/board/controller/AdminBoardController.java
@@ -37,7 +37,7 @@ import com.animal.api.support.service.UserSupportService;
  * 사이트 관리자 페이지의 게시글 관련 기능 클래스
  * 
  * @author Rege-97
- * @since 2025-06-25
+ * @since 2025-06-27
  * @see com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO
  * @see com.animal.api.admin.board.model.request.NoticeInsertRequestDTO
  * @see com.animal.api.board.model.response.AllBoardListResponseDTO
@@ -122,6 +122,38 @@ public class AdminBoardController {
 		} else {
 			return ResponseEntity.status(HttpStatus.OK)
 					.body(new OkResponseDTO<BoardDetailResponseDTO>(200, "게시판 상세 조회 성공", boardDetail));
+		}
+	}
+
+	/**
+	 * 사이트 관리 페이지의 게시글 삭제
+	 * 
+	 * @param idx     게시글 번호
+	 * @param session 로그인 검증을 위한 세션
+	 * @return 성공 또는 실패 메세지
+	 */
+	@DeleteMapping("/{idx}")
+	public ResponseEntity<?> deleteBoard(@PathVariable int idx, HttpSession session) {
+		LoginResponseDTO loginAdmin = (LoginResponseDTO) session.getAttribute("loginAdmin");
+
+		if (loginAdmin == null) { // 로그인 여부 검증
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ErrorResponseDTO(401, "로그인 후 이용해주세요."));
+		}
+
+		if (loginAdmin.getUserTypeIdx() != 3) { // 관리자 회원 검증
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ErrorResponseDTO(403, "관리자만 접근 가능합니다."));
+		}
+
+		int result = adminBoardService.deleteBoard(idx);
+
+		if (result == adminBoardService.DELETE_SUCCESS) {
+			return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<Void>(200, "게시글 삭제 성공", null));
+		} else if (result == adminBoardService.NOMAL_BOARD_NOT_FOUND) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponseDTO(404, "해당 글을 찾을 수 없습니다."));
+		} else if (result == adminBoardService.NOT_NOMAL_BOARD) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "해당 글은 일반게시글이 아닙니다."));
+		} else {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponseDTO(400, "게시글 삭제 실패"));
 		}
 	}
 

--- a/care/src/main/java/com/animal/api/admin/board/mapper/AdminBoardMapper.java
+++ b/care/src/main/java/com/animal/api/admin/board/mapper/AdminBoardMapper.java
@@ -10,6 +10,8 @@ public interface AdminBoardMapper {
 
 	public Integer checkBoardType(int idx);
 
+	public int deleteBoard(int idx);
+
 	public int updateNotice(NoticeUpdateRequestDTO dto);
 
 	public int deleteNotice(int idx);

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardService.java
@@ -12,7 +12,11 @@ public interface AdminBoardService {
 	public static int UPLOAD_SUCCESS = 4;
 	public static int NOT_NOTICE = 5;
 	public static int NOTICE_NOT_FOUND = 6;
+	public static int NOT_NOMAL_BOARD = 7;
+	public static int NOMAL_BOARD_NOT_FOUND = 8;
 	public static int ERROR = -1;
+
+	public int deleteBoard(int idx);
 
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx);
 

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
@@ -20,6 +20,26 @@ public class AdminBoardServiceImple implements AdminBoardService {
 	private FileManager fileManager;
 
 	@Override
+	public int deleteBoard(int idx) {
+		Integer boardTypeIdx = mapper.checkBoardType(idx);
+
+		if (boardTypeIdx == null) {
+			return NOMAL_BOARD_NOT_FOUND;
+		}
+
+		if (boardTypeIdx != 2) { // 공지사항인지 확인
+			return NOT_NOMAL_BOARD;
+		}
+		int result = mapper.deleteBoard(idx);
+
+		result = result > 0 ? DELETE_SUCCESS : ERROR;
+		if (result == DELETE_SUCCESS) { // 게시글 삭제 시 파일도 같이 삭제
+			fileManager.deleteFolder("boards", idx);
+		}
+		return result;
+	}
+
+	@Override
 	public int updateNotice(NoticeUpdateRequestDTO dto, int idx) {
 		Integer boardTypeIdx = mapper.checkBoardType(idx);
 
@@ -53,7 +73,7 @@ public class AdminBoardServiceImple implements AdminBoardService {
 		int result = mapper.deleteNotice(idx);
 
 		result = result > 0 ? DELETE_SUCCESS : ERROR;
-		if (result == DELETE_SUCCESS) {	// 게시글 삭제 시 파일도 같이 삭제
+		if (result == DELETE_SUCCESS) { // 게시글 삭제 시 파일도 같이 삭제
 			fileManager.deleteFolder("boards", idx);
 		}
 		return result;

--- a/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/board/service/AdminBoardServiceImple.java
@@ -27,7 +27,7 @@ public class AdminBoardServiceImple implements AdminBoardService {
 			return NOMAL_BOARD_NOT_FOUND;
 		}
 
-		if (boardTypeIdx != 2) { // 공지사항인지 확인
+		if (boardTypeIdx != 2) { // 자유게시판인지 확인
 			return NOT_NOMAL_BOARD;
 		}
 		int result = mapper.deleteBoard(idx);

--- a/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
+++ b/care/src/main/resources/sql-mapper/board/AdminBoardMapper.xml
@@ -12,6 +12,13 @@ FROM
 WHERE
 	IDX = #{idx}
 </select>
+<delete id="deleteBoard" parameterType="int">
+DELETE
+FROM
+	BOARDS
+WHERE
+	IDX = #{idx}
+</delete>
 <update id="updateNotice" parameterType="com.animal.api.admin.board.model.request.NoticeUpdateRequestDTO">
 UPDATE
 	BOARDS


### PR DESCRIPTION
사이트 관리 페이지에서 일반 게시글 삭제 기능 구현
- 로그인 검증
- 권한 검증
- 삭제 시 해당 폴더도 같이 삭제

엔드포인트 : /api/admin/boards/{idx}

로그인 검증 (401)
![image](https://github.com/user-attachments/assets/ee2142eb-574c-4559-8ee2-28247774c7fd)

글을 찾을 수 없음(404)
![image](https://github.com/user-attachments/assets/986a51f2-3eb7-4388-885e-38abff6839fa)

일반 게시글 아님(400)
![image](https://github.com/user-attachments/assets/d127945d-130a-447f-9726-55d5a98a216d)

삭제 성공(200)
![image](https://github.com/user-attachments/assets/a6286381-5d6a-441e-b3b1-1039588769ec)


