### PR TITLE
Feature/lock account after failed loginsadmin unlock

### DIFF
--- a/care/src/main/java/com/animal/api/admin/member/model/request/MemberUpdateRequestDTO.java
+++ b/care/src/main/java/com/animal/api/admin/member/model/request/MemberUpdateRequestDTO.java
@@ -1,5 +1,7 @@
 package com.animal.api.admin.member.model.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -22,7 +24,9 @@ public class MemberUpdateRequestDTO {
     private String addressDetail;
     private Integer point;
     private Integer status;
-	
+    private Integer locked;     // 계정 잠금 여부 (0/1)
+    private Integer lockCount;  // 로그인 실패 횟수
+    
     // SHELTERS (userType = 2일 때만)
 	private String shelterName;
 	private String shelterTel;

--- a/care/src/main/java/com/animal/api/admin/member/model/response/MemberDatailResopnseDTO.java
+++ b/care/src/main/java/com/animal/api/admin/member/model/response/MemberDatailResopnseDTO.java
@@ -27,7 +27,7 @@ public class MemberDatailResopnseDTO {
 	private String createdAt;
 	private int locked;
 	private int lockCount;
-	private int lockedAt;
+	private String lockedAt;
 	
     // SHELTERS (userType = 2일 때만)
 	private String shelterName;

--- a/care/src/main/java/com/animal/api/admin/member/service/MemberServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/member/service/MemberServiceImple.java
@@ -51,11 +51,15 @@ public class MemberServiceImple implements MemberService {
 	public void updateMember(MemberUpdateRequestDTO dto) {
 		
 		int memberUpdated = memberMapper.updateMember(dto);
+		
 		if(memberUpdated == 0) {
 			throw new CustomException(404, "존재하지 않는 회원입니다.");
 		}
 		
+	    // 1. 기존 유저 정보 가져오기
 		MemberDatailResopnseDTO existing = memberMapper.selectMemberDetail(dto.getUserIdx());
+		
+	    // 2. 보호소 정보가 있다면 업데이트
 		if(existing != null && existing.getUserType() == 2) {
 			memberMapper.updateShelterMember(dto);
 		}

--- a/care/src/main/java/com/animal/api/auth/exception/CustomException.java
+++ b/care/src/main/java/com/animal/api/auth/exception/CustomException.java
@@ -6,9 +6,18 @@ import lombok.Getter;
 public class CustomException extends RuntimeException {
 
 	private final int statusCode;
+	private final Object data;
 
 	public CustomException(int statusCode, String message) {
 		super(message);
 		this.statusCode = statusCode;
+		this.data = null;
 	}
+	
+	// data까지 넘길 수 있는 생성자
+    public CustomException(int statusCode, String message, Object data) {
+        super(message);
+        this.statusCode = statusCode;
+        this.data = data;
+    }
 }

--- a/care/src/main/java/com/animal/api/auth/mapper/AuthMapper.java
+++ b/care/src/main/java/com/animal/api/auth/mapper/AuthMapper.java
@@ -23,4 +23,7 @@ public interface AuthMapper {
     
     // 사용자 비밀번호 찾기 조회 
     UserVO findByUserid(@Param("userid") String userid);
+    
+    //로그인 시 잠금 관련 초기화
+    int updateLockInfo(UserVO user);
 }

--- a/care/src/main/java/com/animal/api/common/aop/email/EmailVerificationCheckAspect.java
+++ b/care/src/main/java/com/animal/api/common/aop/email/EmailVerificationCheckAspect.java
@@ -6,10 +6,12 @@ import javax.servlet.http.HttpSession;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
+import com.animal.api.auth.mapper.AuthMapper;
 import com.animal.api.common.model.OkResponseDTO;
 /**
  * 회원가입 시 이메일 인증 확인 AOP
@@ -19,6 +21,9 @@ import com.animal.api.common.model.OkResponseDTO;
 @Aspect
 @Component
 public class EmailVerificationCheckAspect {
+	
+	@Autowired
+	private AuthMapper authMapper;
 
     /**
      * 이메일 인증이 필요한 컨트롤러 메서드(@RequireEmailVerified)에 대한 AOP 처리
@@ -57,4 +62,3 @@ public class EmailVerificationCheckAspect {
         return joinPoint.proceed();
     }
 }
-

--- a/care/src/main/java/com/animal/api/common/exception/GlobalExceptionHandler.java
+++ b/care/src/main/java/com/animal/api/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.animal.api.common.exception;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,9 +15,19 @@ import com.animal.api.common.model.ErrorResponseDTO;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
-	public ResponseEntity<ErrorResponseDTO> handleCustomException(CustomException e) {
-		ErrorResponseDTO error = new ErrorResponseDTO(e.getStatusCode(), e.getMessage());
-		return ResponseEntity.status(e.getStatusCode()).body(error);
+	public ResponseEntity<Object> handleCustomException(CustomException e) {
+
+	    // 기본 구조 수동 구성
+	    Map<String, Object> error = new LinkedHashMap<>();
+	    error.put("errorCode", e.getStatusCode());
+	    error.put("errorMsg", e.getMessage());
+
+	    // data가 있을 경우만 추가
+	    if (e.getData() != null) {
+	        error.put("data", e.getData());
+	    }
+
+	    return ResponseEntity.status(e.getStatusCode()).body(error);
 	}
 
 	// 기타 예상치 못한 예외도 오류 전가

--- a/care/src/main/java/com/animal/api/email/controller/EmailCertificationController.java
+++ b/care/src/main/java/com/animal/api/email/controller/EmailCertificationController.java
@@ -48,7 +48,7 @@ public class EmailCertificationController {
 		String code = String.format("%06d",new Random().nextInt(999999));
 		
         // 2. 이메일 발송
-        String subject = "[Animal Care] 아이디/비밀번호 찾기 인증번호 안내";
+        String subject = "[유기동물 통합 플랫폼] 아이디/비밀번호 찾기 인증번호 안내";
         String body = "인증번호는 [" + code + "] 입니다. 5분 이내로 입력해주세요.";
 
         emailService.sendEmail(email, subject, body);

--- a/care/src/main/java/com/animal/api/email/controller/EmailUnlockController.java
+++ b/care/src/main/java/com/animal/api/email/controller/EmailUnlockController.java
@@ -1,0 +1,45 @@
+package com.animal.api.email.controller;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.animal.api.auth.exception.CustomException;
+import com.animal.api.common.aop.email.RequireEmailVerified;
+import com.animal.api.common.model.OkResponseDTO;
+import com.animal.api.email.model.request.UnlockRequestDTO;
+import com.animal.api.email.model.request.UnlockVerifyDTO;
+import com.animal.api.email.service.EmailUnlockService;
+
+@RestController
+@RequestMapping("/api/email")
+public class EmailUnlockController {
+	
+    @Autowired
+    private EmailUnlockService emailUnlockService;
+
+    // 잠금 해제용 인증 요청
+    @PostMapping("/unlock-request")
+    public ResponseEntity<?> sendUnlockCode(@RequestBody UnlockRequestDTO req, HttpSession session) {
+    	
+        emailUnlockService.sendUnlockCode(req.getEmail(), session);
+
+        return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<>(200, "잠금 해제용 인증코드를 전송했습니다.", null));
+    }
+
+    //  인증코드 확인용 (기존 인증코드 확인 흐름 재사용)
+    @PostMapping("/unlock-verify")
+    @RequireEmailVerified
+    public ResponseEntity<?> unlockAccount(@RequestBody UnlockVerifyDTO req, HttpSession session) {
+    	
+        emailUnlockService.verifyAndUnlock(req.getCode(), session);
+      
+        return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<>(200, "계정 잠금이 해제되었습니다.", null));
+    }
+}

--- a/care/src/main/java/com/animal/api/email/controller/EmailVerificationController.java
+++ b/care/src/main/java/com/animal/api/email/controller/EmailVerificationController.java
@@ -42,7 +42,7 @@ public class EmailVerificationController {
 		String code = String.format("%06d", new Random().nextInt(999999));
 		
 		//이메일 발송 내역
-		String subject = "[Animal Care] 이메일 인증번호 안내";
+		String subject = "[유기동물 통합 플랫폼] 이메일 인증번호 안내";
 		String body = "인증번호는 [" + code + "] 입니다. 회원가입 화면에 정확히 입력 바랍니다.";
 		
 		emailService.sendEmail(email, subject, body);

--- a/care/src/main/java/com/animal/api/email/model/request/UnlockRequestDTO.java
+++ b/care/src/main/java/com/animal/api/email/model/request/UnlockRequestDTO.java
@@ -1,0 +1,12 @@
+package com.animal.api.email.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UnlockRequestDTO {
+    private String email;
+}

--- a/care/src/main/java/com/animal/api/email/model/request/UnlockVerifyDTO.java
+++ b/care/src/main/java/com/animal/api/email/model/request/UnlockVerifyDTO.java
@@ -1,0 +1,12 @@
+package com.animal.api.email.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UnlockVerifyDTO {
+	private String code;
+}

--- a/care/src/main/java/com/animal/api/email/service/EmailUnlockService.java
+++ b/care/src/main/java/com/animal/api/email/service/EmailUnlockService.java
@@ -1,0 +1,11 @@
+package com.animal.api.email.service;
+
+import javax.servlet.http.HttpSession;
+
+public interface EmailUnlockService {
+	
+	void sendUnlockCode(String email, HttpSession session);
+	
+    void prepareUnlock(String email, String code, HttpSession session);
+    void verifyAndUnlock(String inputCode, HttpSession session);
+}

--- a/care/src/main/java/com/animal/api/email/service/EmailUnlockServiceImple.java
+++ b/care/src/main/java/com/animal/api/email/service/EmailUnlockServiceImple.java
@@ -1,0 +1,105 @@
+package com.animal.api.email.service;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.animal.api.auth.exception.CustomException;
+import com.animal.api.auth.mapper.AuthMapper;
+import com.animal.api.auth.model.vo.UserVO;
+
+@Service
+@Primary
+public class EmailUnlockServiceImple implements EmailUnlockService {
+
+    @Autowired
+    private AuthMapper authMapper;
+    
+    @Autowired
+    private EmailService emailService;
+
+    // 인증코드 생성 로직 이동
+    private String generateRandomCode() {
+        int length = 6;
+        StringBuilder code = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            code.append((int)(Math.random() * 10));
+        }
+        return code.toString();
+    }
+    
+	@Override
+	public void sendUnlockCode(String email, HttpSession session) {
+        UserVO user = authMapper.findByEmail(email);
+        if (user == null) {
+            throw new CustomException(404, "해당 이메일로 가입된 계정이 없습니다.");
+        }
+
+        // 인증코드 생성
+        String code = generateRandomCode();
+
+        prepareUnlock(email, code, session);
+        
+        // 세션 저장
+        session.setAttribute("emailUnlockTarget", user.getId());
+        session.setAttribute("emailUnlockCode", code);
+
+        // 이메일 발송
+        String subject = "[유기동물 통합 플랫폼] 계정 잠금 해제 인증코드 안내";
+        String text = "요청하신 인증코드는 [" + code + "] 입니다.\n\n"
+                    + "본 인증코드는 잠긴 계정을 해제하기 위해 사용됩니다.";
+        emailService.sendEmail(email, subject, text);		
+	}
+	
+    @Override
+    public void prepareUnlock(String email, String code, HttpSession session) {
+        UserVO user = authMapper.findByEmail(email);
+        if (user == null) {
+            throw new CustomException(404, "해당 이메일로 가입된 계정이 없습니다.");
+        }
+
+        session.setAttribute("emailAuthTarget", user.getId());
+        session.setAttribute("emailUnlockTarget", user.getId());
+        session.setAttribute("emailUnlockCode", code);
+    }
+
+    @Override
+    public void verifyAndUnlock(String inputCode, HttpSession session) {
+        String sessionCode = (String) session.getAttribute("emailUnlockCode");
+
+        if (sessionCode == null || inputCode == null || !sessionCode.trim().equals(inputCode.trim())) {
+            throw new CustomException(403, "인증코드가 올바르지 않습니다.");
+        }
+
+        // 세션에서 사용자 ID 꺼냄
+        String targetId = (String) session.getAttribute("emailAuthTarget");
+
+        if (targetId == null) {
+            throw new CustomException(400, "잠금 해제 대상이 지정되지 않았습니다.");
+        }
+
+        // DB에서 사용자 조회
+        UserVO user = authMapper.findUserById(targetId);
+
+        if (user == null || user.getLocked() == 0) {
+            throw new CustomException(404, "계정을 찾을 수 없거나 이미 잠금 해제 상태입니다.");
+        }
+
+        // 잠금 해제 처리
+        user.setLocked(0);
+        user.setLockCount(0);
+        user.setLockedAt(null);
+
+        int result = authMapper.updateLockInfo(user);
+        if (result == 0) {
+            throw new CustomException(500, "잠금 해제에 실패했습니다.");
+        }
+
+        // 세션 정리
+        session.removeAttribute("emailUnlockCode");
+        session.removeAttribute("emailAuthTarget");
+        session.removeAttribute("emailUnlockTarget");
+    }
+}

--- a/care/src/main/resources/sql-mapper/admin/MemberMapper.xml
+++ b/care/src/main/resources/sql-mapper/admin/MemberMapper.xml
@@ -105,7 +105,7 @@
 		WHERE U.IDX = #{userIdx}
 	</select>
 	
-	<update id="updateMember">
+	<update id="updateMember" parameterType="com.animal.api.admin.member.model.request.MemberUpdateRequestDTO">
 	    UPDATE USERS
 	    SET 
 	        NICKNAME = #{nickname},
@@ -117,7 +117,10 @@
 	        ADDRESS = #{address},
 	        ADDRESS_DETAIL = #{addressDetail},
 	        POINT = #{point},
-	        STATUS = #{status}
+	        STATUS = #{status},
+            LOCKED = #{locked},
+	        LOCK_COUNT = #{lockCount},
+	        UPDATED_AT = NOW()
 	    WHERE IDX = #{userIdx}
 	</update>
 	

--- a/care/src/main/resources/sql-mapper/auth/AuthMapper.xml
+++ b/care/src/main/resources/sql-mapper/auth/AuthMapper.xml
@@ -77,6 +77,13 @@
 	      AND STATUS = 1
 	</select>
 
-
+	<update id="updateLockInfo" parameterType="com.animal.api.auth.model.vo.UserVO">
+	    UPDATE USERS
+	    SET LOCKED = #{locked},
+	        LOCK_COUNT = #{lockCount},
+	        LOCKED_AT = #{lockedAt},
+	        UPDATED_AT = NOW()
+	    WHERE ID = #{id}
+	</update>
 
 </mapper>


### PR DESCRIPTION
[일반 사용자 잠금 처리]
- 로그인 실패 시 LOCK_COUNT 증가
- 5회 이상 실패 시 계정 자동 잠금 (LOCKED = 1, LOCKED_AT = now())
- 잠금 상태일 경우 로그인 차단 (403 Forbidden)
- 이메일 인증 성공 시 계정 잠금 해제 (LOCKED = 0, LOCK_COUNT = 0, LOCKED_AT = null)

[관리자 기능 연동]
- 관리자 회원 수정 기능에 LOCKED / LOCK_COUNT 필드 수정 기능 추가
- 관리자는 LOCKED 상태를 수동으로 변경 가능


/care/api/email/unlock-request

잠금으로 인한 이메일 인증 코드 발송 
![image](https://github.com/user-attachments/assets/35b310de-1413-4b21-a6f3-65f4f2094465)

/care/api/email/unlock-verify
잠금해제를 위한 인증코드 인증
![image](https://github.com/user-attachments/assets/cc4109b6-1e3b-4f8d-8210-1804072970f0)
