### PR TITLE
[PR]Feat: admin change point

### DIFF
--- a/care/src/main/java/com/animal/api/admin/member/controller/AdminPointTypeController.java
+++ b/care/src/main/java/com/animal/api/admin/member/controller/AdminPointTypeController.java
@@ -1,0 +1,46 @@
+package com.animal.api.admin.member.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.animal.api.admin.member.model.request.AdminPointTypeUpdateRequestDTO;
+import com.animal.api.admin.member.service.AdminPointTypeService;
+import com.animal.api.common.model.OkResponseDTO;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * [관리자 전용] 포인트 타입 관리 컨트롤러
+ * 
+ * 포인트 타입별 고정 포인트 금액(예: 봉사 후기 작성 시 500포인트)을 수정할 수 있는 관리자 API를 제공합니다
+ * 
+ * @author Whistler95
+ * @since 2025-06-27
+ */
+@RestController
+@RequestMapping("/api/admin/point-types")
+@RequiredArgsConstructor
+public class AdminPointTypeController {
+
+    private final AdminPointTypeService adminPointTypeService;
+
+    /**
+     * [관리자 전용] 포인트 타입 금액 수정 API
+     * 
+     * 봉사 후기 작성, 입양 후기 작성 등의 포인트 타입에 대해 고정 포인트 금액을 수정합니다
+     * 
+     * @param dto 포인트 타입 IDX, 수정할 포인트 금액 정보
+     * @return 성공 메시지
+     */
+    @PutMapping("/update")
+    public ResponseEntity<?> updatePointType(@RequestBody @Valid AdminPointTypeUpdateRequestDTO dto) {
+        adminPointTypeService.updatePointTypePoint(dto);
+        return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<>(200, "포인트 타입 금액 수정 완료", null));
+    }
+}

--- a/care/src/main/java/com/animal/api/admin/member/mapper/AdminPointTypeMapper.java
+++ b/care/src/main/java/com/animal/api/admin/member/mapper/AdminPointTypeMapper.java
@@ -1,0 +1,10 @@
+package com.animal.api.admin.member.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.animal.api.admin.member.model.request.AdminPointTypeUpdateRequestDTO;
+
+@Mapper
+public interface AdminPointTypeMapper {
+    int updatePointTypePoint(AdminPointTypeUpdateRequestDTO dto);
+}

--- a/care/src/main/java/com/animal/api/admin/member/model/request/AdminPointTypeUpdateRequestDTO.java
+++ b/care/src/main/java/com/animal/api/admin/member/model/request/AdminPointTypeUpdateRequestDTO.java
@@ -1,0 +1,13 @@
+package com.animal.api.admin.member.model.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminPointTypeUpdateRequestDTO {
+    private Integer pointTypeIdx; // 수정할 포인트 타입 IDX
+    private Integer point;        // 수정할 포인트 금액
+}

--- a/care/src/main/java/com/animal/api/admin/member/model/request/MemberUpdateRequestDTO.java
+++ b/care/src/main/java/com/animal/api/admin/member/model/request/MemberUpdateRequestDTO.java
@@ -1,7 +1,5 @@
 package com.animal.api.admin.member.model.request;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/care/src/main/java/com/animal/api/admin/member/service/AdminPointTypeService.java
+++ b/care/src/main/java/com/animal/api/admin/member/service/AdminPointTypeService.java
@@ -1,0 +1,7 @@
+package com.animal.api.admin.member.service;
+
+import com.animal.api.admin.member.model.request.AdminPointTypeUpdateRequestDTO;
+
+public interface AdminPointTypeService {
+	 void updatePointTypePoint(AdminPointTypeUpdateRequestDTO dto);
+}

--- a/care/src/main/java/com/animal/api/admin/member/service/AdminPointTypeServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/member/service/AdminPointTypeServiceImple.java
@@ -1,0 +1,26 @@
+package com.animal.api.admin.member.service;
+
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+import com.animal.api.admin.member.mapper.AdminPointTypeMapper;
+import com.animal.api.admin.member.model.request.AdminPointTypeUpdateRequestDTO;
+import com.animal.api.auth.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Primary
+@RequiredArgsConstructor
+public class AdminPointTypeServiceImple implements AdminPointTypeService {
+
+    private final AdminPointTypeMapper adminPointTypeMapper;
+
+    @Override
+    public void updatePointTypePoint(AdminPointTypeUpdateRequestDTO dto) {
+        int result = adminPointTypeMapper.updatePointTypePoint(dto);
+        if (result == 0) {
+            throw new CustomException(404, "해당 포인트 타입이 존재하지 않습니다.");
+        }
+    }
+}

--- a/care/src/main/java/com/animal/api/email/controller/EmailUnlockController.java
+++ b/care/src/main/java/com/animal/api/email/controller/EmailUnlockController.java
@@ -10,13 +10,22 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.animal.api.auth.exception.CustomException;
 import com.animal.api.common.aop.email.RequireEmailVerified;
 import com.animal.api.common.model.OkResponseDTO;
 import com.animal.api.email.model.request.UnlockRequestDTO;
 import com.animal.api.email.model.request.UnlockVerifyDTO;
 import com.animal.api.email.service.EmailUnlockService;
 
+/**
+ * 계정 잠금 해제용 이메일 인증 컨트롤러
+ * 
+ * 	로그인 실패 5회 이상으로 계정이 잠긴 경우
+ * 	이메일 인증을 통해 계정을 수동으로 해제하는 기능 제공
+ * 	기존 이메일 인증 AOP (@RequireEmailVerified) 재사용
+ * 
+ * @author whister95
+ * @since 2025-06-27
+ */
 @RestController
 @RequestMapping("/api/email")
 public class EmailUnlockController {
@@ -24,7 +33,16 @@ public class EmailUnlockController {
     @Autowired
     private EmailUnlockService emailUnlockService;
 
-    // 잠금 해제용 인증 요청
+    /**
+     * 계정 잠금 해제 인증코드 요청 API
+     * 
+     * 입력된 이메일로 인증코드 전송
+     * 인증코드는 HttpSession에 저장됨
+     * 
+     * @param req { email }
+     * @param session HttpSession
+     * @return 성공 메시지
+     */
     @PostMapping("/unlock-request")
     public ResponseEntity<?> sendUnlockCode(@RequestBody UnlockRequestDTO req, HttpSession session) {
     	
@@ -32,8 +50,16 @@ public class EmailUnlockController {
 
         return ResponseEntity.status(HttpStatus.OK).body(new OkResponseDTO<>(200, "잠금 해제용 인증코드를 전송했습니다.", null));
     }
-
-    //  인증코드 확인용 (기존 인증코드 확인 흐름 재사용)
+    /**
+     * 계정 잠금 해제 인증코드 검증 API
+     * 
+     * @RequireEmailVerified AOP로 코드 검증 선처리
+     * 인증 성공 시 해당 세션의 사용자 계정 잠금 해제 (LOCKED = 0, LOCK_COUNT = 0)
+     * 
+     * @param req { code }
+     * @param session HttpSession
+     * @return 성공 메시지
+     */
     @PostMapping("/unlock-verify")
     @RequireEmailVerified
     public ResponseEntity<?> unlockAccount(@RequestBody UnlockVerifyDTO req, HttpSession session) {

--- a/care/src/main/resources/sql-mapper/admin/AdminPointTypeMapper.xml
+++ b/care/src/main/resources/sql-mapper/admin/AdminPointTypeMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  
+ <mapper namespace="com.animal.api.admin.member.mapper.AdminPointTypeMapper">
+
+	 <update id="updatePointTypePoint" parameterType="com.animal.api.admin.member.model.request.AdminPointTypeUpdateRequestDTO">
+	    UPDATE POINT_TYPES
+	    SET POINT = #{point}
+	    WHERE IDX = #{pointTypeIdx}
+	</update>
+	
+ </mapper>


### PR DESCRIPTION
[관리자] 포인트 타입 금액 수정 API

- 포인트 타입별 고정 지급 포인트 금액 수정 기능
- 봉사 후기 작성, 입양 후기 작성 등의 포인트 정책 변경 시 사용
- 엔드포인트: `PUT /api/admin/point-types/update`

pointTypeIdx 1 -> 봉사 후기 / pointTypeIdx-> 2 입양 후기

포인트 수정 완료
![image](https://github.com/user-attachments/assets/f5fad8c7-09be-4c37-9666-4af6a882c635)
