### PR TITLE
[PR]Feature/delete shelter volunteer

### DIFF
--- a/care/src/main/java/com/animal/api/admin/shelter/mapper/AdminShelterMapper.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/mapper/AdminShelterMapper.java
@@ -10,6 +10,10 @@ import com.animal.api.admin.shelter.model.response.ShelterJoinRequestListRespons
 @Mapper
 public interface AdminShelterMapper {
 
+	public Integer checkShelterVolunteer(int idx);
+
+	public int deleteVolunteer(int idx);
+
 	public List<ShelterJoinRequestListResponseDTO> getShelterJoinRequestList(Map map);
 
 	public int getShelterJoinRequestListTotalCnt();

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterService.java
@@ -7,12 +7,17 @@ import com.animal.api.common.model.PageInformationDTO;
 
 public interface AdminShelterService {
 
-	static int UPDATE_SUCCESS = 1;
-	static int NOT_REQUEST = 2;
-	static int APPROVED = 3;
-	static int WITHDRAWN = 4;
-	static int NOT_ERROR = 5;
-	static int ERROR = -1;
+	public static int UPDATE_SUCCESS = 1;
+	public static int NOT_REQUEST = 2;
+	public static int APPROVED = 3;
+	public static int WITHDRAWN = 4;
+	public static int NOT_ERROR = 5;
+	public static int DELETE_SUCCESS = 6;
+	public static int NOT_FOUND_VOLUNTEER = 7;
+	public static int NOT_OWNED_VOLUNTEER = 8;
+	public static int ERROR = -1;
+
+	public int deleteVolunteer(int volunteerIdx, int shelterIdx);
 
 	public List<ShelterJoinRequestListResponseDTO> getShelterJoinRequestList(int cp);
 

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
@@ -32,7 +32,7 @@ public class AdminShelterServiceImple implements AdminShelterService {
 			return NOT_FOUND_VOLUNTEER;
 		}
 
-		if (volunteerIdx != shelterIdx) { // 해당 보호시설의 봉사인지 확인
+		if (userIdx != shelterIdx) { // 해당 보호시설의 봉사인지 확인
 			return NOT_OWNED_VOLUNTEER;
 		}
 		int result = mapper.deleteVolunteer(volunteerIdx);

--- a/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
+++ b/care/src/main/java/com/animal/api/admin/shelter/service/AdminShelterServiceImple.java
@@ -25,6 +25,26 @@ public class AdminShelterServiceImple implements AdminShelterService {
 	private int pageSize = 5;
 
 	@Override
+	public int deleteVolunteer(int volunteerIdx, int shelterIdx) {
+		Integer userIdx = mapper.checkShelterVolunteer(volunteerIdx);
+
+		if (userIdx == null) {
+			return NOT_FOUND_VOLUNTEER;
+		}
+
+		if (volunteerIdx != shelterIdx) { // 해당 보호시설의 봉사인지 확인
+			return NOT_OWNED_VOLUNTEER;
+		}
+		int result = mapper.deleteVolunteer(volunteerIdx);
+
+		result = result > 0 ? DELETE_SUCCESS : ERROR;
+		if (result == DELETE_SUCCESS) { // 봉사 삭제 시 파일도 같이 삭제
+			fileManager.deleteFolder("volunteers", volunteerIdx);
+		}
+		return result;
+	}
+
+	@Override
 	public List<ShelterJoinRequestListResponseDTO> getShelterJoinRequestList(int cp) {
 		if (cp == 0) {
 			cp = 1;

--- a/care/src/main/resources/sql-mapper/shelter/AdminShelterMapper.xml
+++ b/care/src/main/resources/sql-mapper/shelter/AdminShelterMapper.xml
@@ -4,6 +4,22 @@
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
   
 <mapper namespace="com.animal.api.admin.shelter.mapper.AdminShelterMapper">
+
+<select id="checkShelterVolunteer" parameterType="int" resultType="Integer">
+SELECT
+	USER_IDX
+FROM
+	VOLUNTEERS
+WHERE
+	IDX = #{idx}
+</select>
+<delete id="deleteVolunteer" parameterType="int">
+DELETE
+FROM
+	VOLUNTEERS
+WHERE
+	IDX = #{idx}
+</delete>
 <select id="getShelterJoinRequestList" parameterType="Map" resultType="com.animal.api.admin.shelter.model.response.ShelterJoinRequestListResponseDTO">
 SELECT
 	U.IDX,


### PR DESCRIPTION
사이트 관리 페이지에서 특정 보호시설의 봉사를 삭제하는 기능 구현
- 로그인 검증
- 관리자 권한 검증
- 보소시설 검증
- 봉사 유무 검증

엔드포인트 : /api/admin/shelters/{shelterIdx}/volunteers/{volunteerIdx}

로그인 검증 실패(401)
![image](https://github.com/user-attachments/assets/45e57f2b-0241-4517-8e33-df256af0137f)

봉사를 찾을 수 없음(404)
![image](https://github.com/user-attachments/assets/ca53feab-90ce-48b0-b1e4-16c3b3b6b1ce)

해당 보호시설의 봉사가 아님(400)
![image](https://github.com/user-attachments/assets/8e1f04b5-1d20-4066-97d6-d5daa19734e3)

봉사 삭제 성공(200)
![image](https://github.com/user-attachments/assets/d281b834-4b9e-466f-91e3-e34468de3777)
